### PR TITLE
Load library from zenodo

### DIFF
--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -112,7 +112,12 @@ def get_library_data(output_dir: str) -> Tuple[List[Spectrum], bool, int,
             library_spectrums = load_pickled_file(file_name)
             if isinstance(library_spectrums, tuple):
                 # in the case of the case study set that is tuple(query, lib)
-                library_spectrums = library_spectrums[1]
+                if lib_num == 1:  # the case study library
+                    library_spectrums = library_spectrums[1]
+                if lib_num == 2:
+                    # add query and lib from case study: get AllPositive back
+                    library_spectrums = library_spectrums[0] + \
+                                        library_spectrums[1]
             st.write(f"Your selected library: {library_example}")
         else:
             st.write('You have selected the small test library:',
@@ -188,8 +193,10 @@ def gather_zenodo_library(output_folder):
     test_set_all_pos = ("https://zenodo.org/record/4281172/files/testing_que" +
                         "ry_library_s2v_2dec.pickle?download=1")
     test_set_all_pos_file = url_to_file([test_set_all_pos], output_folder)[0]
-    library_dict = {"Case study AllPositive subset":
-                        (test_set_all_pos, test_set_all_pos_file, 1)}
+    library_dict = {
+        "AllPositive dataset": (test_set_all_pos, test_set_all_pos_file, 2),
+        "Case study AllPositive subset":
+            (test_set_all_pos, test_set_all_pos_file, 1)}
     return library_dict
 
 

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -80,8 +80,8 @@ def make_downloads_folder():
     return out_folder
 
 
-def get_library_data(output_dir: str) -> Tuple[List[Spectrum], bool,
-                                Union[pd.DataFrame, None]]:
+def get_library_data(output_dir: str) -> Tuple[List[Spectrum], bool, int,
+                                               Union[pd.DataFrame, None]]:
     """
     Return library, library_similarities as ([Spectrum], df) from user input
 
@@ -92,6 +92,7 @@ def get_library_data(output_dir: str) -> Tuple[List[Spectrum], bool,
     """
     library_spectrums = []  # default so later code doesn't crash
     test_sim_matrix = None
+    lib_num = None
     # gather default libraries
     example_libs_dict, example_libs_list = gather_test_json(
         'testspectrum_library.json')
@@ -107,7 +108,7 @@ def get_library_data(output_dir: str) -> Tuple[List[Spectrum], bool,
         if processed:
             # download from zenodo
             make_folder(output_dir)
-            url_name, file_name = example_libs_dict[library_example]
+            url_name, file_name, lib_num = example_libs_dict[library_example]
             place_holder = st.empty()
             if not os.path.isfile(file_name):
                 file_base = os.path.split(file_name)[-1]
@@ -124,6 +125,7 @@ def get_library_data(output_dir: str) -> Tuple[List[Spectrum], bool,
         else:
             st.write('You have selected the small test library:',
                      library_example)
+            lib_num = 0
             library_spectrums = json_loader(
                 open(example_libs_dict[library_example]))
 
@@ -138,11 +140,12 @@ def get_library_data(output_dir: str) -> Tuple[List[Spectrum], bool,
                 "test_found_matches_similarity_matrix.csv")
             test_sim_matrix = pd.read_csv(test_sim_matrix_file, index_col=0)
         else:
-            st.write("""<p><span style="color:red">Libraries other than the example
-                testspectrum are not implemented yet, so network plotting will not
-                work for this library.</span></p>""", unsafe_allow_html=True)
+            st.write("""<p><span style="color:red">Libraries other than the
+            example testspectrum are not implemented yet, so network plotting
+            will not work for this library.</span></p>""",
+                     unsafe_allow_html=True)
 
-    return library_spectrums, processed, test_sim_matrix
+    return library_spectrums, processed, lib_num, test_sim_matrix
 
 
 @st.cache(allow_output_mutation=True)
@@ -170,8 +173,8 @@ def gather_zenodo_library(output_folder):
     test_set_all_pos = ("https://zenodo.org/record/4281172/files/testing_que" +
                         "ry_library_s2v_2dec.pickle?download=1")
     test_set_all_pos_file = url_to_file([test_set_all_pos], output_folder)[0]
-    library_dict = {"Case study AllPositive subset": (test_set_all_pos,
-                                                      test_set_all_pos_file)}
+    library_dict = {"Case study AllPositive subset":
+                        (test_set_all_pos, test_set_all_pos_file, 1)}
     return library_dict
 
 
@@ -392,6 +395,7 @@ def get_library_matches(documents_query: List[SpectrumDocument],
 class DocumentsLibrary:
     """Dummy class used to circumvent hashing the library for library matching
     """
+
     def __init__(self, documents: List[SpectrumDocument]):
         """
 

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -107,16 +107,8 @@ def get_library_data(output_dir: str) -> Tuple[List[Spectrum], bool, int,
     if library_example:
         if processed:
             # download from zenodo
-            make_folder(output_dir)
-            url_name, file_name, lib_num = example_libs_dict[library_example]
-            place_holder = st.empty()
-            if not os.path.isfile(file_name):
-                file_base = os.path.split(file_name)[-1]
-                place_holder.write(
-                    f"Downloading {file_base} from zenodo...")
-                urlretrieve(url_name, file_name)
-                place_holder.write("Download successful.")
-            place_holder.empty()
+            file_name, lib_num = download_zenodo_library(
+                example_libs_dict, library_example, output_dir)
             library_spectrums = load_pickled_file(file_name)
             if isinstance(library_spectrums, tuple):
                 # in the case of the case study set that is tuple(query, lib)
@@ -146,6 +138,29 @@ def get_library_data(output_dir: str) -> Tuple[List[Spectrum], bool, int,
                      unsafe_allow_html=True)
 
     return library_spectrums, processed, lib_num, test_sim_matrix
+
+
+def download_zenodo_library(example_libs_dict: dict, library_example: str,
+                            output_dir: str) -> Tuple[str, int]:
+    """Downloads the library from zenodo and returns the file_path and lib_num
+
+    Args:
+    -------
+    example_libs_dict
+    library_example
+    output_dir
+    """
+    make_folder(output_dir)
+    url_name, file_name, lib_num = example_libs_dict[library_example]
+    place_holder = st.empty()
+    if not os.path.isfile(file_name):
+        file_base = os.path.split(file_name)[-1]
+        place_holder.write(
+            f"Downloading {file_base} from zenodo...")
+        urlretrieve(url_name, file_name)
+        place_holder.write("Download successful.")
+    place_holder.empty()
+    return file_name, lib_num
 
 
 @st.cache(allow_output_mutation=True)

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -424,17 +424,23 @@ def cached_library_matching(documents_query: List[SpectrumDocument],
     documents_query:
         Query spectra in SpectrumDocument format
     documents_library:
-        Library spectra in SpectrumDocument format # todo
+        Library spectra in DocumentsLibrary format
     model:
         A trained Spec2Vec model
     topn:
         The amount of Spec2Vec top candidates to retrieve
-    model_num
+    lib_num:
+        The library number used for library matching. This is a workaround for
+        the caching of the library matches as the library is expensive to hash.
+        Library is not hashed and with model_num it is kept into account if the
+        library changes.
+    model_num:
         The model number used for library matching. This is a workaround for
-        the caching of the library matches as the model is expensive to hash,
-        it is not hashed and with model_num it is kept into account if the
+        the caching of the library matches as the model is expensive to hash.
+        Model is not hashed and with model_num it is kept into account if the
         model changes.
     """
+    # pylint: disable=too-many-arguments
     if lib_num:  # variable for the hash function
         pass
     if model_num:  # variable for the hash function

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -131,6 +131,11 @@ def get_model(out_folder: str) -> Tuple[Union[Word2Vec, None],
     """Return (Word2Vec model, model number) and print some info in the app
 
     Models will be downloaded from zenodo to ../ms2query/downloads
+
+    Args:
+    -------
+    out_folder:
+        Folder of where to download the models
     """
     st.write("#### Spec2Vec model")
     # get all data from zenodo

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -227,8 +227,9 @@ def make_folder(output_folder):
 
 
 def do_spectrum_processing(query_spectrums: List[Spectrum],
-                           library_spectrums: List[Spectrum]) -> Tuple[
-    List[SpectrumDocument], List[SpectrumDocument]]:
+                           library_spectrums: List[Spectrum],
+                           library_is_processed: bool) -> Tuple[
+        List[SpectrumDocument], List[SpectrumDocument]]:
     """Process query, library into SpectrumDocuments and write processing info
 
     Args:
@@ -260,7 +261,10 @@ def do_spectrum_processing(query_spectrums: List[Spectrum],
             value of [{settings["loss_mz_from"]}, {settings["loss_mz_to"]}]""")
 
     documents_query = process_spectrums(query_spectrums, **settings)
-    documents_library = process_spectrums(library_spectrums, **settings)
+    if library_is_processed:
+        documents_library = library_spectrums
+    else:
+        documents_library = process_spectrums(library_spectrums, **settings)
 
     return documents_query, documents_library
 

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -67,7 +67,8 @@ def get_query() -> List[Spectrum]:
     return query_spectrums
 
 
-def get_library_data() -> Tuple[List[Spectrum], Union[pd.DataFrame, None]]:
+def get_library_data() -> Tuple[List[Spectrum], bool,
+                                Union[pd.DataFrame, None]]:
     """
     Return library, library_similarities as ([Spectrum], df) from user input
     """
@@ -77,8 +78,13 @@ def get_library_data() -> Tuple[List[Spectrum], Union[pd.DataFrame, None]]:
     # gather default libraries
     example_libs_dict, example_libs_list = gather_test_json(
         'testspectrum_library.json')
+    # zenodo_dict = gather_zenodo_library(outdir)
+    # example_libs_dict.update(zenodo_dict)
+    # example_libs_list.append(list(zenodo_dict.keys()))
     library_example = st.sidebar.selectbox("Load a library spectrum example",
                                            example_libs_list)
+    processed = False
+    # processed = bool(library_example in example_libs_dict.keys())
     st.write("#### Library spectra")
     if library_example and not library_file:
         st.write('You have selected an example library:', library_example)
@@ -105,7 +111,7 @@ def get_library_data() -> Tuple[List[Spectrum], Union[pd.DataFrame, None]]:
             testspectrum are not implemented yet, so network plotting will not
             work for this library.</span></p>""", unsafe_allow_html=True)
 
-    return library_spectrums, test_sim_matrix
+    return library_spectrums, processed, test_sim_matrix
 
 
 def get_model() -> Tuple[Union[Word2Vec, None], Union[int, None]]:

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -145,7 +145,7 @@ def get_library_data(output_dir: str) -> Tuple[List[Spectrum], bool,
     return library_spectrums, processed, test_sim_matrix
 
 
-@st.cache
+@st.cache(allow_output_mutation=True)
 def load_pickled_file(file_name: str):
     """Returns contents from the pickle file
 

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -67,6 +67,18 @@ def get_query() -> List[Spectrum]:
     return query_spectrums
 
 
+def make_downloads_folder():
+    """Return user adjustable download folder, default is ms2query/downloads
+    """
+    base_dir = os.path.split(os.path.dirname(__file__))[0]
+    out_folder = os.path.join(base_dir, "downloads")
+    different_out_folder = st.sidebar.text_input(
+        "Change the download folder location. Default is: ms2query/downloads")
+    if different_out_folder:
+        out_folder = different_out_folder
+    return out_folder
+
+
 def get_library_data() -> Tuple[List[Spectrum], bool,
                                 Union[pd.DataFrame, None]]:
     """
@@ -114,19 +126,14 @@ def get_library_data() -> Tuple[List[Spectrum], bool,
     return library_spectrums, processed, test_sim_matrix
 
 
-def get_model() -> Tuple[Union[Word2Vec, None], Union[int, None]]:
+def get_model(out_folder: str) -> Tuple[Union[Word2Vec, None],
+                                        Union[int, None]]:
     """Return (Word2Vec model, model number) and print some info in the app
 
     Models will be downloaded from zenodo to ../ms2query/downloads
     """
     st.write("#### Spec2Vec model")
     # get all data from zenodo
-    base_dir = os.path.split(os.path.dirname(__file__))[0]
-    out_folder = os.path.join(base_dir, "downloads")
-    different_out_folder = st.sidebar.text_input(
-        "Change the download folder location. Default is: ms2query/downloads")
-    if different_out_folder:
-        out_folder = different_out_folder
     model_name, model_file, model_num = get_zenodo_models(out_folder)
     model = None
     if model_name:

--- a/ms2query_app.py
+++ b/ms2query_app.py
@@ -22,7 +22,7 @@ query_spectrums = get_query()
 # get the download folder which is user adjustable
 downloads_folder = make_downloads_folder()
 # load library file in sidebar
-library_spectrums, lib_is_processed, sim_matrix = get_library_data(
+library_spectrums, lib_is_processed, lib_num, sim_matrix = get_library_data(
     downloads_folder)
 
 # load a s2v model in sidebar
@@ -49,10 +49,6 @@ get_example_library_matches()
 do_library_matching = st.checkbox("Do library matching")
 if do_library_matching:
     if all([documents_query, documents_library, model]):
-        if lib_is_processed:  # todo: change this in get_lib func
-            lib_num = 1
-        else:
-            lib_num = 0
         found_match = get_library_matches(documents_query, documents_library,
                                           model, lib_num, model_num)
     else:

--- a/ms2query_app.py
+++ b/ms2query_app.py
@@ -19,7 +19,7 @@ input_warning_placeholder = st.empty()  # input warning for later
 # load query spectrum
 query_spectrums = get_query()
 # load library file in sidebar
-library_spectrums, sim_matrix = get_library_data()
+library_spectrums, lib_is_processed, sim_matrix = get_library_data()
 
 # load a s2v model in sidebar
 # todo: make more user friendly, currently there is no standard func to do this
@@ -34,7 +34,8 @@ if not query_spectrums or not library_spectrums or not model:
 
 # processing of query and library spectra into SpectrumDocuments
 documents_query, documents_library = do_spectrum_processing(query_spectrums,
-                                                            library_spectrums)
+                                                            library_spectrums,
+                                                            lib_is_processed)
 
 # do library matching
 st.write("## Library matching")

--- a/ms2query_app.py
+++ b/ms2query_app.py
@@ -22,7 +22,8 @@ query_spectrums = get_query()
 # get the download folder which is user adjustable
 downloads_folder = make_downloads_folder()
 # load library file in sidebar
-library_spectrums, lib_is_processed, sim_matrix = get_library_data()
+library_spectrums, lib_is_processed, sim_matrix = get_library_data(
+    downloads_folder)
 
 # load a s2v model in sidebar
 # todo: make more user friendly, currently there is no standard func to do this

--- a/ms2query_app.py
+++ b/ms2query_app.py
@@ -49,8 +49,12 @@ get_example_library_matches()
 do_library_matching = st.checkbox("Do library matching")
 if do_library_matching:
     if all([documents_query, documents_library, model]):
+        if lib_is_processed:  # todo: change this in get_lib func
+            lib_num = 1
+        else:
+            lib_num = 0
         found_match = get_library_matches(documents_query, documents_library,
-                                          model, model_num)
+                                          model, lib_num, model_num)
     else:
         do_library_matching = False
         st.write("""<p><span style="color:red">Please specify input files.

--- a/ms2query_app.py
+++ b/ms2query_app.py
@@ -1,6 +1,7 @@
 import streamlit as st
 from ms2query.app_helpers import get_query
 from ms2query.app_helpers import get_library_data
+from ms2query.app_helpers import make_downloads_folder
 from ms2query.app_helpers import get_model
 from ms2query.app_helpers import do_spectrum_processing
 from ms2query.app_helpers import get_example_library_matches
@@ -18,13 +19,15 @@ input_warning_placeholder = st.empty()  # input warning for later
 
 # load query spectrum
 query_spectrums = get_query()
+# get the download folder which is user adjustable
+downloads_folder = make_downloads_folder()
 # load library file in sidebar
 library_spectrums, lib_is_processed, sim_matrix = get_library_data()
 
 # load a s2v model in sidebar
 # todo: make more user friendly, currently there is no standard func to do this
 # for quick testing C:\Users\joris\Documents\eScience_data\data\trained_models\spec2vec_library_testing_4000removed_2dec.model
-model, model_num = get_model()
+model, model_num = get_model(downloads_folder)
 
 # write an input warning
 if not query_spectrums or not library_spectrums or not model:


### PR DESCRIPTION
Downloads and loads two libraries in the app as processed spectra from a pickle file.

- AllPositive complete dataset
- The case study library

It only downloads one file for both as the pickled object is a Tuple(query_case_study, library_case_study). Together these form the whole AllPositive dataset again.