### PR TITLE
Library similarity

### DIFF
--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -394,8 +394,9 @@ def get_library_matches(documents_query: List[SpectrumDocument],
     st.write("These are the library matches for your query")
     if found_matches_s2v:
         first_found_match = found_matches_s2v[0]
-        st.dataframe(first_found_match.sort_values(
-            "s2v_score", ascending=False).iloc[:show_topn])
+        first_found_match = first_found_match.sort_values(
+            "s2v_score", ascending=False)
+        st.dataframe(first_found_match.iloc[:show_topn])
         return first_found_match
     return None
 
@@ -483,8 +484,8 @@ def get_library_similarities(found_match: pd.DataFrame,
         sim_matrix = pd.read_csv(test_sim_matrix_file, index_col=0)
     elif library_num in (1, 2):
         # construct the slice of the similarity matrix in order of matches ind
-        match_inds = found_match.sort_values("s2v_score", ascending=False)\
-            .iloc[:100].index.to_list()  # take 100 as a max value
+        # take 100 as a max value, same as in library_matching
+        match_inds = found_match.iloc[:100].index.to_list()
         match_inchi14 = [documents_library[ind]._obj.get("inchikey")[:14]
                          for ind in match_inds]
         sim_slice_inds = get_sim_matrix_lookup(match_inchi14)
@@ -518,7 +519,7 @@ def get_sim_matrix_lookup(match_inchi14: List[str]):
     return indices
 
 
-def subset_sim_matrix(indices):
+def subset_sim_matrix(indices: List[str]) -> np.array:
     sim_file = ("C:\\users\\joris\\Documents\\eScience_data\\data\\Similarit" +
                 "y_matrix_AllPositive\\similarities_AllInchikeys14_daylight2" +
                 "048_jaccard.npy")
@@ -548,6 +549,15 @@ def make_network_plot(found_match: pd.DataFrame,
         Dataframe containing the tanimoto similarities of the library spectra
         amongst each other
     """
+    def_show_topn = 10  # default for topn results to show
+    if len(documents_library) < def_show_topn:
+        def_show_topn = len(documents_library)
+    cols = st.beta_columns([1, 3])
+    with cols[0]:
+        show_topn = int(st.text_input("Show top n matches (1-100)",
+                                      value=def_show_topn))
+    found_match = found_match.iloc[:show_topn]
+
     plot_placeholder = st.empty()  # add a place for the plot
     # add sliders to adjust network plot
     col1, col2 = st.beta_columns(2)

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -505,10 +505,9 @@ def get_library_similarities(found_match: pd.DataFrame,
         match_inchi14 = [documents_library[ind]._obj.get("inchikey")[:14]
                          for ind in match_inds]
         sim_slice_inds = get_sim_matrix_lookup(match_inchi14, output_folder)
-        sim_matrix = subset_sim_matrix(sim_slice_inds, output_folder)
-    else:
-        st.write("Similarity matrix not yet implemented for this library.")
-    return sim_matrix
+        return subset_sim_matrix(sim_slice_inds, output_folder)
+
+    return None
 
 
 def get_sim_matrix_lookup(match_inchi14: List[str],

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -519,11 +519,16 @@ def get_sim_matrix_lookup(match_inchi14: List[str],
     output_folder:
         Location to download/get similarity matrix and metadata from
     """
-    # todo: download from zenodo
+    metadata_link = "https://zenodo.org/record/4286949/files/metadata_AllIn" +\
+        "chikeys14.csv?download=1"
     metadata_name = "metadata_AllInchikeys14.csv"
     metadata_file = os.path.join(output_folder, metadata_name)
     if not os.path.exists(metadata_file):
-        st.write(f"Similarity matrix data is not present in {output_folder}")
+        place_holder = st.empty()
+        place_holder.write("Downloading {metadata_name} from zenodo...")
+        urlretrieve(metadata_link, metadata_file)
+        place_holder.empty()
+
     with open(metadata_file, 'r') as inf:
         inf.readline()
         inchi_dict = {}

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -492,7 +492,6 @@ def get_library_similarities(found_match: pd.DataFrame,
         Location to download/get similarity matrix and metadata from
     """
     # pylint: disable=protected-access
-    sim_matrix = None
     if library_num == 0:
         test_sim_matrix_file = os.path.join(
             os.path.split(os.path.dirname(__file__))[0], "tests",

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -499,7 +499,6 @@ def get_library_similarities(found_match: pd.DataFrame,
                          for ind in match_inds]
         sim_slice_inds = get_sim_matrix_lookup(match_inchi14, output_folder)
         sim_matrix = subset_sim_matrix(sim_slice_inds, output_folder)
-        print(sim_matrix.shape)
     else:
         st.write("Similarity matrix not yet implemented for this library.")
     return sim_matrix

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -519,14 +519,14 @@ def get_sim_matrix_lookup(match_inchi14: List[str],
     output_folder:
         Location to download/get similarity matrix and metadata from
     """
-    metadata_link = "https://zenodo.org/record/4286949/files/metadata_AllIn" +\
+    metadata_url = "https://zenodo.org/record/4286949/files/metadata_AllIn" +\
         "chikeys14.csv?download=1"
     metadata_name = "metadata_AllInchikeys14.csv"
     metadata_file = os.path.join(output_folder, metadata_name)
     if not os.path.exists(metadata_file):
         place_holder = st.empty()
         place_holder.write(f"Downloading {metadata_name} from zenodo...")
-        urlretrieve(metadata_link, metadata_file)
+        urlretrieve(metadata_url, metadata_file)
         place_holder.empty()
 
     with open(metadata_file, 'r') as inf:

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -525,7 +525,7 @@ def get_sim_matrix_lookup(match_inchi14: List[str],
     metadata_file = os.path.join(output_folder, metadata_name)
     if not os.path.exists(metadata_file):
         place_holder = st.empty()
-        place_holder.write("Downloading {metadata_name} from zenodo...")
+        place_holder.write(f"Downloading {metadata_name} from zenodo...")
         urlretrieve(metadata_link, metadata_file)
         place_holder.empty()
 

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -504,7 +504,7 @@ def get_sim_matrix_lookup(match_inchi14: List[str]):
     """
     # todo: download from zenodo
     metadata_file = ("C:\\users\\joris\\Documents\\eScience_data\\data\\Simi" +
-                     "larity_matrix_AllPositive\metadata_AllInchikeys14.csv")
+                     "larity_matrix_AllPositive\\metadata_AllInchikeys14.csv")
     user_input = st.text_input("Give path to metadata of similarity matrix")
     if user_input:
         metadata_file = user_input

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -80,8 +80,7 @@ def make_downloads_folder():
     return out_folder
 
 
-def get_library_data(output_dir: str) -> Tuple[List[Spectrum], bool, int,
-                                               Union[pd.DataFrame, None]]:
+def get_library_data(output_dir: str) -> Tuple[List[Spectrum], bool, int]:
     """
     Return library, library_similarities as ([Spectrum], df) from user input
 
@@ -91,7 +90,6 @@ def get_library_data(output_dir: str) -> Tuple[List[Spectrum], bool, int,
         Folder to download zenodo libraries to
     """
     library_spectrums = []  # default so later code doesn't crash
-    test_sim_matrix = None
     lib_num = None
     # gather default libraries
     example_libs_dict, example_libs_list = gather_test_json(
@@ -129,20 +127,7 @@ def get_library_data(output_dir: str) -> Tuple[List[Spectrum], bool, int,
     # write library info
     if library_spectrums:
         st.write(f"Your library contains {len(library_spectrums)} spectra.")
-
-        # load similarity matrix, not implemented apart from test sim matrix
-        if library_example == 'testspectrum_library.json':
-            test_sim_matrix_file = os.path.join(
-                os.path.split(os.path.dirname(__file__))[0], "tests",
-                "test_found_matches_similarity_matrix.csv")
-            test_sim_matrix = pd.read_csv(test_sim_matrix_file, index_col=0)
-        else:
-            st.write("""<p><span style="color:red">Libraries other than the
-            example testspectrum are not implemented yet, so network plotting
-            will not work for this library.</span></p>""",
-                     unsafe_allow_html=True)
-
-    return library_spectrums, processed, lib_num, test_sim_matrix
+    return library_spectrums, processed, lib_num
 
 
 def download_zenodo_library(example_libs_dict: dict, library_example: str,
@@ -473,6 +458,30 @@ def cached_library_matching(documents_query: List[SpectrumDocument],
         presearch_based_on=[f"spec2vec-top{topn}", "parentmass"],
         **{"allowed_missing_percentage": 100})
     return found_matches_s2v
+
+
+def get_library_similarities(library_num: int):
+    """
+
+    Args:
+    ------
+    library_num:
+        The library number, 0 means the example library, 1 and 2 (subset of)
+        AllPositive library
+    """
+    # load similarity matrix, not implemented apart from test sim matrix
+    test_sim_matrix = None
+    if library_num == 0:
+        test_sim_matrix_file = os.path.join(
+            os.path.split(os.path.dirname(__file__))[0], "tests",
+            "test_found_matches_similarity_matrix.csv")
+        test_sim_matrix = pd.read_csv(test_sim_matrix_file, index_col=0)
+    else:
+        st.write("""<p><span style="color:red">Libraries other than the
+                example testspectrum are not implemented yet, so network plotting
+                will not work for this library.</span></p>""",
+                 unsafe_allow_html=True)
+    return test_sim_matrix
 
 
 def make_network_plot(found_match: pd.DataFrame,

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -98,7 +98,8 @@ def get_library_data(output_dir: str) -> Tuple[List[Spectrum], bool, int]:
     zenodo_dict = gather_zenodo_library(output_dir)
     example_libs_dict.update(zenodo_dict)
     example_libs_list.extend(list(zenodo_dict.keys()))
-    library_example = st.sidebar.selectbox("Choose a spectrum library",
+    library_example = st.sidebar.selectbox("""Choose a spectrum library (will 
+    trigger large download if library not present in download folder)""",
                                            example_libs_list)
     processed = bool(library_example in zenodo_dict.keys())
 
@@ -265,7 +266,8 @@ def get_zenodo_models(output_folder: str = "downloads") -> Tuple[str, str,
         Folder to download to
     """
     model_dict = get_zenodo_models_dict(output_folder)
-    model_name = st.sidebar.selectbox("Choose a Spec2Vec model",
+    model_name = st.sidebar.selectbox("""Choose a Spec2Vec model (will trigger
+    large download if model not present in download folder)""",
                                       options=[""] + list(model_dict.keys()))
     model_file = None
     model_num = None
@@ -302,7 +304,7 @@ def do_spectrum_processing(query_spectrums: List[Spectrum],
                            library_spectrums: List[Union[Spectrum,
                                                          SpectrumDocument]],
                            library_is_processed: bool) -> Tuple[
-        List[SpectrumDocument], List[SpectrumDocument]]:
+    List[SpectrumDocument], List[SpectrumDocument]]:
     """Process query, library into SpectrumDocuments and write processing info
 
     Args:
@@ -519,8 +521,8 @@ def get_sim_matrix_lookup(match_inchi14: List[str],
     output_folder:
         Location to download/get similarity matrix and metadata from
     """
-    metadata_url = "https://zenodo.org/record/4286949/files/metadata_AllIn" +\
-        "chikeys14.csv?download=1"
+    metadata_url = "https://zenodo.org/record/4286949/files/metadata_AllIn" + \
+                   "chikeys14.csv?download=1"
     metadata_name = "metadata_AllInchikeys14.csv"
     metadata_file = os.path.join(output_folder, metadata_name)
     if not os.path.exists(metadata_file):
@@ -553,8 +555,8 @@ def subset_sim_matrix(indices: List[int],
     output_folder:
         Location to download/get similarity matrix and metadata from
     """
-    sim_url = "https://zenodo.org/record/4286949/files/similarities_AllInch" +\
-        "ikeys14_daylight2048_jaccard.npy?download=1"
+    sim_url = "https://zenodo.org/record/4286949/files/similarities_AllInch" + \
+              "ikeys14_daylight2048_jaccard.npy?download=1"
     sim_name = "similarities_AllInchikeys14_daylight2048_jaccard.npy"
     sim_file = os.path.join(output_folder, sim_name)
     if not os.path.exists(sim_file):

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -497,8 +497,8 @@ def get_library_similarities(found_match: pd.DataFrame,
         test_sim_matrix_file = os.path.join(
             os.path.split(os.path.dirname(__file__))[0], "tests",
             "test_found_matches_similarity_matrix.csv")
-        sim_matrix = pd.read_csv(test_sim_matrix_file, index_col=0)
-    elif library_num in (1, 2):
+        return pd.read_csv(test_sim_matrix_file, index_col=0)
+    if library_num in (1, 2):
         # construct the slice of the similarity matrix in order of matches ind
         # take 100 as a max value, same as in library_matching
         match_inds = found_match.iloc[:100].index.to_list()

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -1,6 +1,6 @@
 import os
 import pickle
-from typing import Tuple, List, Union
+from typing import Tuple, List, Union, Dict
 import numpy as np
 import pandas as pd
 import streamlit as st
@@ -132,15 +132,20 @@ def get_library_data(output_dir: str) -> Tuple[List[Spectrum], bool, int]:
     return library_spectrums, processed, lib_num
 
 
-def download_zenodo_library(example_libs_dict: dict, library_example: str,
+def download_zenodo_library(example_libs_dict: Dict[str, Tuple[str, str, int]],
+                            library_example: str,
                             output_dir: str) -> Tuple[str, int]:
     """Downloads the library from zenodo and returns the file_path and lib_num
 
     Args:
     -------
-    example_libs_dict
+    example_libs_dict:
+        Dict linking the library name in the app to the zenodo url, the path
+        of where the library should be downloaded and the library number
     library_example
+        The library name in the app that is chosen from user input
     output_dir
+        Folder to download zenodo libraries to
     """
     make_folder(output_dir)
     url_name, file_name, lib_num = example_libs_dict[library_example]
@@ -169,7 +174,7 @@ def load_pickled_file(file_name: str):
     return contents
 
 
-def gather_zenodo_library(output_folder):
+def gather_zenodo_library(output_folder: str):
     """Gather file and url info for zenodo libraries
 
     Args:

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -553,10 +553,16 @@ def subset_sim_matrix(indices: List[int],
     output_folder:
         Location to download/get similarity matrix and metadata from
     """
+    sim_url = "https://zenodo.org/record/4286949/files/similarities_AllInch" +\
+        "ikeys14_daylight2048_jaccard.npy?download=1"
     sim_name = "similarities_AllInchikeys14_daylight2048_jaccard.npy"
     sim_file = os.path.join(output_folder, sim_name)
     if not os.path.exists(sim_file):
-        st.write(f"Similarity matrix data is not present in {output_folder}")
+        place_holder = st.empty()
+        place_holder.write(f"Downloading {sim_name} from zenodo...")
+        urlretrieve(sim_url, sim_file)
+        place_holder.empty()
+
     sim_map = np.lib.format.open_memmap(sim_file, dtype="float64", mode="r")
     row_slice = np.take(sim_map, indices, 0)
     final_slice = np.take(row_slice, indices, 1)

--- a/ms2query/app_helpers.py
+++ b/ms2query/app_helpers.py
@@ -549,6 +549,7 @@ def make_network_plot(found_match: pd.DataFrame,
         Dataframe containing the tanimoto similarities of the library spectra
         amongst each other
     """
+    # pylint: disable=too-many-locals
     def_show_topn = 10  # default for topn results to show
     if len(documents_library) < def_show_topn:
         def_show_topn = len(documents_library)

--- a/ms2query/networking.py
+++ b/ms2query/networking.py
@@ -63,7 +63,7 @@ def add_library_connections(graph, similarity_matrix, lib_ids):
 
 def do_networking(query_id: str,
                   matches: pd.DataFrame,
-                  similarity_matrix: pd.DataFrame,
+                  similarity_matrix: Union[np.array, pd.DataFrame],
                   library_documents: List[SpectrumDocument],
                   attribute_key: str = 's2v_score',
                   cutoff: Union[int, float] = 0.4,

--- a/ms2query_app.py
+++ b/ms2query_app.py
@@ -61,7 +61,8 @@ if do_library_matching:
 st.write("## Networking")
 plot_true = st.checkbox("Plot network of found matches")
 if plot_true and do_library_matching:
-    sim_matrix = get_library_similarities(lib_num)
+    sim_matrix = get_library_similarities(
+        found_match, documents_library, lib_num)
     if sim_matrix is not None:
         make_network_plot(found_match, documents_library, sim_matrix)
 elif plot_true:  # library matching is not done yet, but plot button is clicked

--- a/ms2query_app.py
+++ b/ms2query_app.py
@@ -12,8 +12,8 @@ from ms2query.app_helpers import get_library_similarities
 
 st.title("Ms2query")
 st.write("""
-Upload your query and library spectra files in json format in the sidebar.
-Query the library using a Spec2Vec model and inspect the results! 
+Upload your query spectrum, and choose a spectrum library and Spec2Vec model in
+the sidebar. Query the library and inspect the results!
 """)
 st.write("## Input information")
 input_warning_placeholder = st.empty()  # input warning for later
@@ -27,14 +27,12 @@ library_spectrums, lib_is_processed, lib_num = get_library_data(
     downloads_folder)
 
 # load a s2v model in sidebar
-# todo: make more user friendly, currently there is no standard func to do this
-# for quick testing C:\Users\joris\Documents\eScience_data\data\trained_models\spec2vec_library_testing_4000removed_2dec.model
 model, model_num = get_model(downloads_folder)
 
 # write an input warning
 if not query_spectrums or not library_spectrums or not model:
     input_warning_placeholder.markdown("""<p><span style="color:red">Please
-    upload a query, library and model file in the sidebar.</span></p>""",
+    choose a query, library and model in the sidebar.</span></p>""",
                                        unsafe_allow_html=True)
 
 # processing of query and library spectra into SpectrumDocuments
@@ -59,7 +57,9 @@ if do_library_matching:
 
 # do networking
 st.write("## Networking")
-plot_true = st.checkbox("Plot network of found matches")
+st.write("""This will trigger a large download if library similarities are not
+yet present in the download folder.""")
+plot_true = st.checkbox("""Plot network of found matches""")
 if plot_true and do_library_matching:
     sim_matrix = get_library_similarities(
         found_match, documents_library, lib_num, downloads_folder)

--- a/ms2query_app.py
+++ b/ms2query_app.py
@@ -7,6 +7,7 @@ from ms2query.app_helpers import do_spectrum_processing
 from ms2query.app_helpers import get_example_library_matches
 from ms2query.app_helpers import get_library_matches
 from ms2query.app_helpers import make_network_plot
+from ms2query.app_helpers import get_library_similarities
 
 
 st.title("Ms2query")
@@ -22,7 +23,7 @@ query_spectrums = get_query()
 # get the download folder which is user adjustable
 downloads_folder = make_downloads_folder()
 # load library file in sidebar
-library_spectrums, lib_is_processed, lib_num, sim_matrix = get_library_data(
+library_spectrums, lib_is_processed, lib_num = get_library_data(
     downloads_folder)
 
 # load a s2v model in sidebar
@@ -60,10 +61,8 @@ if do_library_matching:
 st.write("## Networking")
 plot_true = st.checkbox("Plot network of found matches")
 if plot_true and do_library_matching:
-    if sim_matrix is None:
-        st.write("""<p><span style="color:red">Does not work yet for custom
-            libraries.</span></p>""", unsafe_allow_html=True)
-    else:
+    sim_matrix = get_library_similarities(lib_num)
+    if sim_matrix is not None:
         make_network_plot(found_match, documents_library, sim_matrix)
 elif plot_true:  # library matching is not done yet, but plot button is clicked
     st.write("""<p><span style="color:red">Please specify input files and do

--- a/ms2query_app.py
+++ b/ms2query_app.py
@@ -62,7 +62,7 @@ st.write("## Networking")
 plot_true = st.checkbox("Plot network of found matches")
 if plot_true and do_library_matching:
     sim_matrix = get_library_similarities(
-        found_match, documents_library, lib_num)
+        found_match, documents_library, lib_num, downloads_folder)
     if sim_matrix is not None:
         make_network_plot(found_match, documents_library, sim_matrix)
 elif plot_true:  # library matching is not done yet, but plot button is clicked

--- a/ms2query_app.py
+++ b/ms2query_app.py
@@ -65,6 +65,8 @@ if plot_true and do_library_matching:
         found_match, documents_library, lib_num, downloads_folder)
     if sim_matrix is not None:
         make_network_plot(found_match, documents_library, sim_matrix)
+    else:
+        st.write("Similarity matrix not yet implemented for this library.")
 elif plot_true:  # library matching is not done yet, but plot button is clicked
     st.write("""<p><span style="color:red">Please specify input files and do
             library matching.</span></p>""", unsafe_allow_html=True)


### PR DESCRIPTION
The library similarity matrix is now downloaded from zenodo and then accessed from disk using the np.memmap functionality.

Some issues still:
- Sometimes the app resets, probably because of some buttons inside buttons (https://discuss.streamlit.io/t/the-button-inside-a-button-seems-to-reset-the-whole-app-why/1051/11)
- In the network plot, nodes are still shown that are not connected at all to the query node but surpass thresholds.
