### PR TITLE
Define spectrum processing functions

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -7,6 +7,36 @@ on:
 
 jobs:
 
+  thorough_check:
+    name: Thorough code check / python-3.8 / ubuntu-latest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Python info
+        run: |
+          which python
+          python --version
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+      - name: Show pip list
+        run: |
+          pip list
+      - name: Run test with coverage
+        run: pytest --cov --cov-report term --cov-report xml
+      - name: Check style against standards using prospector
+        run: prospector -o grouped -o pylint:pylint-report.txt
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
   basic_checks:
     name: Basic code checks / python-${{ matrix.python-version }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -15,6 +45,10 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version: ['3.7', '3.8']
+        exclude:
+          # already tested in first_check job
+          - python-version: 3.8
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -32,10 +66,6 @@ jobs:
       - name: Show pip list
         run: |
           pip list
-      - name: Run unit tests
+      - name: Run tests
         run: |
           pytest
-      - name: Check style against standards using prospector
-        shell: bash -l {0}
-        run: prospector -o grouped -o pylint:pylint-report.txt
-

--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,0 +1,25 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.7
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+        python setup.py sdist bdist_wheel
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@main
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/iomega/ms2query/CI%20Build)
 ![GitHub](https://img.shields.io/github/license/iomega/ms2query)
-[![fair-software.eu](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8B%20%20%E2%97%8F%20%20%E2%97%8B-orange)](https://fair-software.eu)
+[![PyPI](https://img.shields.io/pypi/v/ms2query)](https://pypi.org/project/ms2query/)
+[![fair-software.eu](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8B-yellow)](https://fair-software.eu)
 
 <img src="https://github.com/iomega/ms2query/blob/main/images/ms2query_logo.svg" width="280">
 

--- a/ms2query/s2v_functions.py
+++ b/ms2query/s2v_functions.py
@@ -48,7 +48,8 @@ def set_spec2vec_defaults(**settings: Dict[str, Union[int, bool]]) \
 def post_process_s2v(spectrum: Spectrum,
                      **settings: Dict[str, Union[int, bool]]) \
         -> Union[Spectrum, None]:
-    """Returns a processed matchms.Spectrum.Spectrum
+    """Processing of spectrums
+    TODO: to be updated to new processing pipeline. Or replace.
 
     Args:
     ----------

--- a/ms2query/spectrum_processing.py
+++ b/ms2query/spectrum_processing.py
@@ -89,7 +89,7 @@ def set_spec2vec_defaults(**settings: Dict[str, Union[int, bool]]) \
     return settings
 
 
-def spectrum_processing_s2v(spectrum: Spectrum,
+def spectrum_processing_s2v(spectrum: SpectrumType,
                             **settings: Dict[str, Union[int, bool]]) \
     -> Union[Spectrum, None]:
     """Spectrum processing required for computing Spec2Vec scores.

--- a/ms2query/spectrum_processing.py
+++ b/ms2query/spectrum_processing.py
@@ -72,6 +72,7 @@ def set_spec2vec_defaults(**settings: Dict[str, Union[int, bool]]) \
         Change default settings
     """
     defaults = {"mz_from": 10.0,
+                "n_required": 1,
                 "ratio_desired": 0.5,
                 "intensity_from": 0.001,
                 "n_max": 1000,

--- a/ms2query/spectrum_processing.py
+++ b/ms2query/spectrum_processing.py
@@ -3,10 +3,14 @@ and inspection is expected to happen prior to running MS2Query and is not taken
 into account here. Processing here hence refers to inspecting, filtering, adjusting
 the spectrum peaks (m/z and intensities).
 """
+from typing import Dict, Union
+import numpy as np
 from matchms.typing import SpectrumType
+from matchms.filtering import normalize_intensities, select_by_mz
+
 
 def set_minimal_processing_defaults(**settings: Dict[str, Union[int, float]]) \
-        -> Dict[str, Union[int, bool]]:
+    -> Dict[str, Union[int, bool]]:
     """Set default argument values (where no user input is given).
 
     Args:
@@ -27,8 +31,9 @@ def set_minimal_processing_defaults(**settings: Dict[str, Union[int, float]]) \
     return settings
 
 
-def spectrum_processing_minimal(spectrums: SpectrumType,
-                                **settings: Dict[str, Union[int, float]) -> Union[Spectrum, None]:
+def spectrum_processing_minimal(spectrum: SpectrumType,
+                                **settings: Dict[str, Union[int, float]]) \
+    -> Union[SpectrumType, None]:
     """Minimal necessary spectrum processing that is required by MS2Query.
     This mostly includes intensity normalization and setting spectrums to None
     when they do not meet the minimum requirements.
@@ -50,8 +55,8 @@ def spectrum_processing_minimal(spectrums: SpectrumType,
     """
     settings = set_minimal_processing_defaults(**settings)
     spectrum = normalize_intensities(spectrum)
-    spectrum = select_by_mz(spectrum, mz_from=settings["mz_from"], mz_to=None)
-    spectrum = require_peaks_below_mz(spectrum, n_required=settings["n_required_below_1000"]
+    spectrum = select_by_mz(spectrum, mz_from=settings["mz_from"], mz_to=np.inf)
+    spectrum = require_peaks_below_mz(spectrum, n_required=settings["n_required_below_1000"],
                                       max_mz=settings["max_mz_required"])
     return spectrum
 
@@ -61,7 +66,7 @@ def require_peaks_below_mz(spectrum_in: SpectrumType,
                            max_mz: float = 1000.0) -> SpectrumType:
     """Spectrum will be set to None when it has fewer peaks than required.
 
-    Parameters
+    Parametersgit 
     ----------
     spectrum_in:
         Input spectrum.

--- a/ms2query/spectrum_processing.py
+++ b/ms2query/spectrum_processing.py
@@ -33,7 +33,7 @@ def set_minimal_processing_defaults(**settings: Union[int, float]
 
 
 def spectrum_processing_minimal(spectrum: SpectrumType,
-                                **settings: Dict[str, Union[int, float]]
+                                **settings: Union[int, float]
                                 ) -> Union[SpectrumType, None]:
     """Minimal necessary spectrum processing that is required by MS2Query.
     This mostly includes intensity normalization and setting spectra to None
@@ -94,8 +94,8 @@ def set_spec2vec_defaults(**settings: Union[int, float]
 
 
 def spectrum_processing_s2v(spectrum: SpectrumType,
-                            **settings: Dict[str, Union[int, bool]]
-                            ) -> Union[SpectrumType, None]:
+                            **settings: Union[int, float]
+                            ) -> Union[SpectrumType]:
     """Spectrum processing required for computing Spec2Vec scores.
 
     Args:

--- a/ms2query/spectrum_processing.py
+++ b/ms2query/spectrum_processing.py
@@ -1,0 +1,83 @@
+"""Functions to handle spectrum processing steps. Any metadata related cleaning
+and inspection is expected to happen prior to running MS2Query and is not taken
+into account here. Processing here hence refers to inspecting, filtering, adjusting
+the spectrum peaks (m/z and intensities).
+"""
+from matchms.typing import SpectrumType
+
+def set_minimal_processing_defaults(**settings: Dict[str, Union[int, float]]) \
+        -> Dict[str, Union[int, bool]]:
+    """Set default argument values (where no user input is given).
+
+    Args:
+    ----------
+    **settings:
+        Change default settings
+    """
+    defaults = {"mz_from": 10.0,
+                "n_required_below_1000": 5,
+                "intensity_from": 0.001,
+                "max_mz_required": 1000.0,
+                }
+
+    # Set default parameters or replace by **settings input
+    for key in defaults:
+        if key not in settings:
+            settings[key] = defaults[key]
+    return settings
+
+
+def spectrum_processing_minimal(spectrums: SpectrumType,
+                                **settings: Dict[str, Union[int, float]) -> Union[Spectrum, None]:
+    """Minimal necessary spectrum processing that is required by MS2Query.
+    This mostly includes intensity normalization and setting spectrums to None
+    when they do not meet the minimum requirements.
+
+    Args:
+    ----------
+    spectrum:
+        Spectrum to process
+    mz_from
+        Set lower threshold for m/z peak positions. Default is 0.0.
+    n_required_below_1000
+        Number of minimal required peaks with m/z below 1000.0Da for a spectrum
+        to be considered. Spectrums not meeting this criteria will be set to None.
+    intensity_from
+        Set lower threshold for peak intensity. Default is 10.0.
+    max_mz_required
+        Only peaks <= max_mz_required will be counted to check if spectrum
+        contains sufficient peaks to be considered.
+    """
+    settings = set_minimal_processing_defaults(**settings)
+    spectrum = normalize_intensities(spectrum)
+    spectrum = select_by_mz(spectrum, mz_from=settings["mz_from"], mz_to=None)
+    spectrum = require_peaks_below_mz(spectrum, n_required=settings["n_required_below_1000"]
+                                      max_mz=settings["max_mz_required"])
+    return spectrum
+
+
+def require_peaks_below_mz(spectrum_in: SpectrumType,
+                           n_required: int = 10,
+                           max_mz: float = 1000.0) -> SpectrumType:
+    """Spectrum will be set to None when it has fewer peaks than required.
+
+    Parameters
+    ----------
+    spectrum_in:
+        Input spectrum.
+    n_required:
+        Number of minimum required peaks. Spectra with fewer peaks will be set
+        to 'None'.
+    max_mz:
+        Only peaks <= max_mz will be counted to check if spectrum contains
+        sufficient peaks to be considered (>= n_required).
+    """
+    if spectrum_in is None:
+        return None
+
+    spectrum = spectrum_in.clone()
+
+    if spectrum.peaks.mz[spectrum.peaks.mz < max_mz].size < n_required:
+        return None
+
+    return spectrum

--- a/ms2query/spectrum_processing.py
+++ b/ms2query/spectrum_processing.py
@@ -1,7 +1,7 @@
 """Functions to handle spectrum processing steps. Any metadata related cleaning
 and inspection is expected to happen prior to running MS2Query and is not taken
-into account here. Processing here hence refers to inspecting, filtering, adjusting
-the spectrum peaks (m/z and intensities).
+into account here. Processing here hence refers to inspecting, filtering,
+adjusting the spectrum peaks (m/z and intensities).
 """
 from typing import Dict, Union
 import numpy as np
@@ -10,8 +10,8 @@ from matchms.filtering import normalize_intensities, \
     select_by_mz, select_by_intensity, reduce_to_number_of_peaks, add_losses
 
 
-def set_minimal_processing_defaults(**settings: Dict[str, Union[int, float]]) \
-    -> Dict[str, Union[int, bool]]:
+def set_minimal_processing_defaults(**settings: Union[int, float]
+                                    ) -> Dict[str, Union[int, float]]:
     """Set default argument values (where no user input is given).
 
     Args:
@@ -33,10 +33,10 @@ def set_minimal_processing_defaults(**settings: Dict[str, Union[int, float]]) \
 
 
 def spectrum_processing_minimal(spectrum: SpectrumType,
-                                **settings: Dict[str, Union[int, float]]) \
-    -> Union[SpectrumType, None]:
+                                **settings: Dict[str, Union[int, float]]
+                                ) -> Union[SpectrumType, None]:
     """Minimal necessary spectrum processing that is required by MS2Query.
-    This mostly includes intensity normalization and setting spectrums to None
+    This mostly includes intensity normalization and setting spectra to None
     when they do not meet the minimum requirements.
 
     Args:
@@ -47,7 +47,8 @@ def spectrum_processing_minimal(spectrum: SpectrumType,
         Set lower threshold for m/z peak positions. Default is 10.0.
     n_required_below_mz
         Number of minimal required peaks with m/z below 1000.0Da for a spectrum
-        to be considered. Spectrums not meeting this criteria will be set to None.
+        to be considered.
+        Spectra not meeting this criteria will be set to None.
     intensity_from
         Set lower threshold for peak intensity. Default is 0.001.
     max_mz_required
@@ -56,14 +57,20 @@ def spectrum_processing_minimal(spectrum: SpectrumType,
     """
     settings = set_minimal_processing_defaults(**settings)
     spectrum = normalize_intensities(spectrum)
-    spectrum = select_by_intensity(spectrum, intensity_from=settings["intensity_from"])
-    spectrum = select_by_mz(spectrum, mz_from=settings["mz_from"], mz_to=np.inf)
-    spectrum = require_peaks_below_mz(spectrum, n_required=settings["n_required_below_mz"],
-                                      max_mz=settings["max_mz_required"])
+    spectrum = select_by_intensity(spectrum,
+                                   intensity_from=settings["intensity_from"])
+    spectrum = select_by_mz(spectrum,
+                            mz_from=settings["mz_from"],
+                            mz_to=np.inf)
+    spectrum = require_peaks_below_mz(
+        spectrum,
+        n_required=settings["n_required_below_mz"],
+        max_mz=settings["max_mz_required"])
     return spectrum
 
-def set_spec2vec_defaults(**settings: Dict[str, Union[int, bool]]) \
-        -> Dict[str, Union[int, bool]]:
+
+def set_spec2vec_defaults(**settings: Union[int, float]
+                          ) -> Dict[str, Union[int, float]]:
     """Set spec2vec default argument values"(where no user input is given)".
 
     Args
@@ -79,7 +86,6 @@ def set_spec2vec_defaults(**settings: Dict[str, Union[int, bool]]) \
                 "loss_mz_from": 5.0,
                 "loss_mz_to": 200.0,
                 }
-
     # Set default parameters or replace by **settings input
     for key in defaults:
         if key not in settings:
@@ -88,8 +94,8 @@ def set_spec2vec_defaults(**settings: Dict[str, Union[int, bool]]) \
 
 
 def spectrum_processing_s2v(spectrum: SpectrumType,
-                            **settings: Dict[str, Union[int, bool]]) \
-    -> Union[SpectrumType, None]:
+                            **settings: Dict[str, Union[int, bool]]
+                            ) -> Union[SpectrumType, None]:
     """Spectrum processing required for computing Spec2Vec scores.
 
     Args:
@@ -109,12 +115,14 @@ def spectrum_processing_s2v(spectrum: SpectrumType,
         Maximum allowed m/z value for losses. Default is 1000.0.
     """
     settings = set_spec2vec_defaults(**settings)
-    spectrum = reduce_to_number_of_peaks(spectrum,
-                                         n_required=settings["n_required"],
-                                         ratio_desired=settings["ratio_desired"],
-                                         n_max=settings["n_max"])
+    spectrum = reduce_to_number_of_peaks(
+        spectrum,
+        n_required=settings["n_required"],
+        ratio_desired=settings["ratio_desired"],
+        n_max=settings["n_max"])
 
-    spectrum = add_losses(spectrum, loss_mz_from=settings["loss_mz_from"],
+    spectrum = add_losses(spectrum,
+                          loss_mz_from=settings["loss_mz_from"],
                           loss_mz_to=settings["loss_mz_to"])
     return spectrum
 
@@ -124,7 +132,7 @@ def require_peaks_below_mz(spectrum_in: SpectrumType,
                            max_mz: float = 1000.0) -> SpectrumType:
     """Spectrum will be set to None when it has fewer peaks than required.
 
-    Parametersgit
+    Args:
     ----------
     spectrum_in:
         Input spectrum.

--- a/ms2query/spectrum_processing.py
+++ b/ms2query/spectrum_processing.py
@@ -6,7 +6,7 @@ the spectrum peaks (m/z and intensities).
 from typing import Dict, Union
 import numpy as np
 from matchms.typing import SpectrumType
-from matchms.filtering import normalize_intensities, select_by_mz
+from matchms.filtering import normalize_intensities, select_by_mz, select_by_intensity
 
 
 def set_minimal_processing_defaults(**settings: Dict[str, Union[int, float]]) \
@@ -43,21 +43,94 @@ def spectrum_processing_minimal(spectrum: SpectrumType,
     spectrum:
         Spectrum to process
     mz_from
-        Set lower threshold for m/z peak positions. Default is 0.0.
+        Set lower threshold for m/z peak positions. Default is 10.0.
     n_required_below_1000
         Number of minimal required peaks with m/z below 1000.0Da for a spectrum
         to be considered. Spectrums not meeting this criteria will be set to None.
     intensity_from
-        Set lower threshold for peak intensity. Default is 10.0.
+        Set lower threshold for peak intensity. Default is 0.001.
     max_mz_required
         Only peaks <= max_mz_required will be counted to check if spectrum
         contains sufficient peaks to be considered.
     """
     settings = set_minimal_processing_defaults(**settings)
     spectrum = normalize_intensities(spectrum)
+    spectrum = select_by_intensity(spectrum, intensity_from=setting["intensity_from"])
     spectrum = select_by_mz(spectrum, mz_from=settings["mz_from"], mz_to=np.inf)
     spectrum = require_peaks_below_mz(spectrum, n_required=settings["n_required_below_1000"],
                                       max_mz=settings["max_mz_required"])
+    return spectrum
+
+def set_spec2vec_defaults(**settings: Dict[str, Union[int, bool]]) \
+        -> Dict[str, Union[int, bool]]:
+    """Set spec2vec default argument values"(where no user input is given)".
+
+    Args
+    ----------
+    **settings:
+        Change default settings
+    """
+    defaults = {"mz_from": 0,
+                "mz_to": 1000,
+                "n_required": 1,
+                "ratio_desired": 0.5,
+                "intensity_from": 0.001,
+                "n_max": 1000,
+                "loss_mz_from": 5.0,
+                "loss_mz_to": 200.0,
+                "intensity_weighting_power": 0.5,
+                "allowed_missing_percentage": 10.0,
+                }
+
+    # Set default parameters or replace by **settings input
+    for key in defaults:
+        if key not in settings:
+            settings[key] = defaults[key]
+    return settings
+
+
+def spectrum_processing_s2v(spectrum: Spectrum,
+                            **settings: Dict[str, Union[int, bool]]) \
+    -> Union[Spectrum, None]:
+    """Spectrum processing required for computing Spec2Vec scores.
+
+    Args:
+    ----------
+    spectrum:
+        Spectrum to process
+    mz_from
+        Set lower threshold for m/z peak positions. Default is 0.0.
+    mz_to
+        Set upper threshold for m/z peak positions. Default is 1000.0.
+    n_required
+        Number of minimal required peaks for a spectrum to be considered.
+    ratio_desired
+        Number of minimum required peaks. Spectra with fewer peaks will be set
+        to 'None'. Default is 1.
+    intensity_from
+        Set lower threshold for peak intensity. Default is 10.0.
+    n_max
+        Maximum number of peaks to be kept per spectrum. Default is 1000.
+    loss_mz_from
+        Minimum allowed m/z value for losses. Default is 0.0.
+    loss_mz_to
+        Maximum allowed m/z value for losses. Default is 1000.0.
+    intensity_weighting_power
+        Weighing of individual word (=peak) vectors.
+    allowed_missing_percentage
+        Allowed percentage of the entire spectrum that is allowed to not be
+        covered my the pretrained Spec2Vec model.
+    """
+    settings = set_spec2vec_defaults(**settings)
+    spectrum = reduce_to_number_of_peaks(spectrum,
+                                         n_required=settings["n_required"],
+                                         ratio_desired=settings["ratio_desired"],
+                                         n_max=settings["n_max"])
+    if spectrum is None:
+        return None
+
+    spectrum = add_losses(spectrum, loss_mz_from=settings["loss_mz_from"],
+                          loss_mz_to=settings["loss_mz_to"])
     return spectrum
 
 
@@ -66,7 +139,7 @@ def require_peaks_below_mz(spectrum_in: SpectrumType,
                            max_mz: float = 1000.0) -> SpectrumType:
     """Spectrum will be set to None when it has fewer peaks than required.
 
-    Parametersgit 
+    Parametersgit
     ----------
     spectrum_in:
         Input spectrum.

--- a/ms2query/spectrum_processing.py
+++ b/ms2query/spectrum_processing.py
@@ -124,6 +124,8 @@ def spectrum_processing_s2v(spectrum: SpectrumType,
     spectrum = add_losses(spectrum,
                           loss_mz_from=settings["loss_mz_from"],
                           loss_mz_to=settings["loss_mz_to"])
+    assert spectrum is None, \
+        "Expects Spectrum that has high enough quality and is not None"
     return spectrum
 
 

--- a/ms2query/spectrum_processing.py
+++ b/ms2query/spectrum_processing.py
@@ -6,7 +6,8 @@ the spectrum peaks (m/z and intensities).
 from typing import Dict, Union
 import numpy as np
 from matchms.typing import SpectrumType
-from matchms.filtering import normalize_intensities, select_by_mz, select_by_intensity
+from matchms.filtering import normalize_intensities, \
+    select_by_mz, select_by_intensity, reduce_to_number_of_peaks, add_losses
 
 
 def set_minimal_processing_defaults(**settings: Dict[str, Union[int, float]]) \
@@ -55,7 +56,7 @@ def spectrum_processing_minimal(spectrum: SpectrumType,
     """
     settings = set_minimal_processing_defaults(**settings)
     spectrum = normalize_intensities(spectrum)
-    spectrum = select_by_intensity(spectrum, intensity_from=setting["intensity_from"])
+    spectrum = select_by_intensity(spectrum, intensity_from=settings["intensity_from"])
     spectrum = select_by_mz(spectrum, mz_from=settings["mz_from"], mz_to=np.inf)
     spectrum = require_peaks_below_mz(spectrum, n_required=settings["n_required_below_1000"],
                                       max_mz=settings["max_mz_required"])

--- a/ms2query/spectrum_processing.py
+++ b/ms2query/spectrum_processing.py
@@ -91,7 +91,7 @@ def set_spec2vec_defaults(**settings: Dict[str, Union[int, bool]]) \
 
 def spectrum_processing_s2v(spectrum: SpectrumType,
                             **settings: Dict[str, Union[int, bool]]) \
-    -> Union[Spectrum, None]:
+    -> Union[SpectrumType, None]:
     """Spectrum processing required for computing Spec2Vec scores.
 
     Args:

--- a/ms2query/spectrum_processing.py
+++ b/ms2query/spectrum_processing.py
@@ -124,7 +124,7 @@ def spectrum_processing_s2v(spectrum: SpectrumType,
     spectrum = add_losses(spectrum,
                           loss_mz_from=settings["loss_mz_from"],
                           loss_mz_to=settings["loss_mz_to"])
-    assert spectrum is None, \
+    assert spectrum is not None, \
         "Expects Spectrum that has high enough quality and is not None"
     return spectrum
 

--- a/ms2query/spectrum_processing.py
+++ b/ms2query/spectrum_processing.py
@@ -20,7 +20,7 @@ def set_minimal_processing_defaults(**settings: Dict[str, Union[int, float]]) \
         Change default settings
     """
     defaults = {"mz_from": 10.0,
-                "n_required_below_1000": 5,
+                "n_required_below_mz": 5,
                 "intensity_from": 0.001,
                 "max_mz_required": 1000.0,
                 }
@@ -45,7 +45,7 @@ def spectrum_processing_minimal(spectrum: SpectrumType,
         Spectrum to process
     mz_from
         Set lower threshold for m/z peak positions. Default is 10.0.
-    n_required_below_1000
+    n_required_below_mz
         Number of minimal required peaks with m/z below 1000.0Da for a spectrum
         to be considered. Spectrums not meeting this criteria will be set to None.
     intensity_from
@@ -58,7 +58,7 @@ def spectrum_processing_minimal(spectrum: SpectrumType,
     spectrum = normalize_intensities(spectrum)
     spectrum = select_by_intensity(spectrum, intensity_from=settings["intensity_from"])
     spectrum = select_by_mz(spectrum, mz_from=settings["mz_from"], mz_to=np.inf)
-    spectrum = require_peaks_below_mz(spectrum, n_required=settings["n_required_below_1000"],
+    spectrum = require_peaks_below_mz(spectrum, n_required=settings["n_required_below_mz"],
                                       max_mz=settings["max_mz_required"])
     return spectrum
 
@@ -71,16 +71,12 @@ def set_spec2vec_defaults(**settings: Dict[str, Union[int, bool]]) \
     **settings:
         Change default settings
     """
-    defaults = {"mz_from": 0,
-                "mz_to": 1000,
-                "n_required": 1,
+    defaults = {"mz_from": 10.0,
                 "ratio_desired": 0.5,
                 "intensity_from": 0.001,
                 "n_max": 1000,
                 "loss_mz_from": 5.0,
                 "loss_mz_to": 200.0,
-                "intensity_weighting_power": 0.5,
-                "allowed_missing_percentage": 10.0,
                 }
 
     # Set default parameters or replace by **settings input
@@ -99,36 +95,23 @@ def spectrum_processing_s2v(spectrum: SpectrumType,
     ----------
     spectrum:
         Spectrum to process
-    mz_from
-        Set lower threshold for m/z peak positions. Default is 0.0.
-    mz_to
-        Set upper threshold for m/z peak positions. Default is 1000.0.
     n_required
         Number of minimal required peaks for a spectrum to be considered.
     ratio_desired
         Number of minimum required peaks. Spectra with fewer peaks will be set
         to 'None'. Default is 1.
-    intensity_from
-        Set lower threshold for peak intensity. Default is 10.0.
     n_max
         Maximum number of peaks to be kept per spectrum. Default is 1000.
     loss_mz_from
         Minimum allowed m/z value for losses. Default is 0.0.
     loss_mz_to
         Maximum allowed m/z value for losses. Default is 1000.0.
-    intensity_weighting_power
-        Weighing of individual word (=peak) vectors.
-    allowed_missing_percentage
-        Allowed percentage of the entire spectrum that is allowed to not be
-        covered my the pretrained Spec2Vec model.
     """
     settings = set_spec2vec_defaults(**settings)
     spectrum = reduce_to_number_of_peaks(spectrum,
                                          n_required=settings["n_required"],
                                          ratio_desired=settings["ratio_desired"],
                                          n_max=settings["n_max"])
-    if spectrum is None:
-        return None
 
     spectrum = add_losses(spectrum, loss_mz_from=settings["loss_mz_from"],
                           loss_mz_to=settings["loss_mz_to"])

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,10 @@
+sonar.organization=iomega
+sonar.projectKey=iomega_ms2query
+sonar.host.url=https://sonarcloud.io
+sonar.sources=ms2query/
+sonar.tests=tests/
+sonar.links.homepage=https://github.com/iomega/ms2query
+sonar.links.scm=https://github.com/iomega/ms2query
+sonar.links.issue=https://github.com/iomega/ms2query/issues
+sonar.links.ci=https://github.com/iomega/ms2query/actions
+sonar.python.coverage.reportPaths=coverage.xml

--- a/tests/test_spectrum_processing.py
+++ b/tests/test_spectrum_processing.py
@@ -56,20 +56,20 @@ def test_spectrum_processing_minimal_default():
         "Expected None because the number of peaks (4) is less than the default threshold (10)."
 
 
-def test_spectrum_processing_minimal_set_n_required():
+def test_spectrum_processing_minimal_set_n_required_and_max_mz():
     spectrum_in = Spectrum(mz=np.array([5, 110, 220, 330, 399, 440], dtype="float"),
                            intensities=np.array([10, 10, 1, 10, 20, 100], dtype="float"))
-    spectrum = spectrum_processing_minimal(spectrum_in, n_required_below_1000=4, max_mz_required=400)
+    spectrum = spectrum_processing_minimal(spectrum_in, n_required_below_mz=4, max_mz_required=400)
 
     assert np.all(spectrum.peaks.mz == spectrum_in.peaks.mz[1:]), "Expected different m/z values"
     assert np.all(spectrum.peaks.intensities == np.array([0.1 , 0.01, 0.1 , 0.2 , 1.  ])), \
-        "Expected different, normalized intensities"
+        "Expected different intensities"
 
 
 def test_spectrum_processing_minimal_set_n_required_intensity_from():
     spectrum_in = Spectrum(mz=np.array([5, 110, 220, 330, 440], dtype="float"),
                            intensities=np.array([10, 10, 0.1, 10, 101], dtype="float"))
-    spectrum = spectrum_processing_minimal(spectrum_in, n_required_below_1000=4)
+    spectrum = spectrum_processing_minimal(spectrum_in, n_required_below_mz=4)
 
     assert spectrum is None, \
         "Expected None because 1 peak has m/z > max_mz_required and 1 peak has intensity < intensity_from"
@@ -96,5 +96,5 @@ def test_spectrum_processing_s2v():
 #                                      "precursor_mz": 240.0})
 #     spectrum = spectrum_processing_s2v(spectrum_in, n_max=4)
 #     assert isinstance(spectrum, Spectrum), "Expected output to be Spectrum."
-#     assert spectrum.peaks == spectrum_in.peaks[1:], "Expected spectrum peaks to be unchanged by function"
+#     assert spectrum.peaks == spectrum_in.peaks[1:], "Expected only the first peak to be removed"
 #     assert np.all(spectrum.losses.mz == np.array([ 20., 130.])), "Expected other losses"

--- a/tests/test_spectrum_processing.py
+++ b/tests/test_spectrum_processing.py
@@ -1,0 +1,64 @@
+import numpy as np
+from matchms import Spectrum
+from ms2query.spectrum_processing import require_peaks_below_mz, spectrum_processing_minimal
+
+
+def test_require_peaks_below_mz_no_params():
+    """Test default"""
+    mz = np.array([110, 220, 330, 440], dtype="float")
+    intensities = np.array([0, 1, 10, 100], dtype="float")
+    spectrum_in = Spectrum(mz=mz, intensities=intensities)
+
+    spectrum = require_peaks_below_mz(spectrum_in)
+
+    assert spectrum is None, "Expected None because the number of peaks (4) is less than the default threshold (10)."
+
+
+def test_require_peaks_below_mz_required_4():
+    """Test with adjustment of n_required."""
+    mz = np.array([110, 220, 330, 440], dtype="float")
+    intensities = np.array([0, 1, 10, 100], dtype="float")
+    spectrum_in = Spectrum(mz=mz, intensities=intensities)
+
+    spectrum = require_peaks_below_mz(spectrum_in, n_required=4)
+
+    assert spectrum == spectrum_in, "Expected the spectrum to qualify because the number of peaks (4) is equal to the" \
+                                "required number (4)."
+
+
+def test_require_peaks_below_mz_required_4_below_max_mz():
+    """Test with adjustment of n_required but with lower max_mz."""
+    mz = np.array([110, 220, 330, 440], dtype="float")
+    intensities = np.array([0, 1, 10, 100], dtype="float")
+    spectrum_in = Spectrum(mz=mz, intensities=intensities)
+
+    spectrum = require_peaks_below_mz(spectrum_in, n_required=4, max_mz=400)
+
+    assert spectrum is None, \
+        "Expected None since peaks with mz<=max_mz is less than n_required."
+
+
+def test_empty_spectrum():
+    spectrum_in = None
+    spectrum = require_peaks_below_mz(spectrum_in)
+
+    assert spectrum is None, "Expected different handling of None spectrum."
+
+
+def test_spectrum_processing_minimal_default():
+    spectrum_in = Spectrum(mz=np.array([110, 220, 330, 440], dtype="float"),
+                           intensities=np.array([10, 1, 10, 100], dtype="float"))
+    spectrum = spectrum_processing_minimal(spectrum_in)
+
+    assert spectrum is None, \
+        "Expected None because the number of peaks (4) is less than the default threshold (10)."
+
+
+def test_spectrum_processing_minimal_set_n_required():
+    spectrum_in = Spectrum(mz=np.array([5, 110, 220, 330, 440], dtype="float"),
+                           intensities=np.array([10, 10, 1, 10, 100], dtype="float"))
+    spectrum = spectrum_processing_minimal(spectrum_in, n_required_below_1000=4)
+
+    assert np.all(spectrum.peaks.mz == spectrum_in.peaks.mz[1:]), "Expected m/z values to be unchanged"
+    assert np.all(spectrum.peaks.intensities == np.array([0.1 , 0.01, 0.1 , 1.  ])), \
+        "Expected different, normalized intensities"

--- a/tests/test_spectrum_processing.py
+++ b/tests/test_spectrum_processing.py
@@ -4,7 +4,6 @@ from ms2query.spectrum_processing import require_peaks_below_mz, \
     spectrum_processing_minimal, spectrum_processing_s2v
 
 
-
 def test_require_peaks_below_mz_no_params():
     """Test default"""
     mz = np.array([110, 220, 330, 440], dtype="float")
@@ -13,7 +12,9 @@ def test_require_peaks_below_mz_no_params():
 
     spectrum = require_peaks_below_mz(spectrum_in)
 
-    assert spectrum is None, "Expected None because the number of peaks (4) is less than the default threshold (10)."
+    assert spectrum is None, \
+        "Expected None, because the number of peaks (4) is less than the " \
+        "default threshold (10)."
 
 
 def test_require_peaks_below_mz_required_4():
@@ -24,8 +25,9 @@ def test_require_peaks_below_mz_required_4():
 
     spectrum = require_peaks_below_mz(spectrum_in, n_required=4)
 
-    assert spectrum == spectrum_in, "Expected the spectrum to qualify because the number of peaks (4) is equal to the" \
-                                "required number (4)."
+    assert spectrum == spectrum_in, \
+        "Expected the spectrum to qualify because the number of peaks (4) " \
+        "is equal to the required number (4)."
 
 
 def test_require_peaks_below_mz_required_4_below_max_mz():
@@ -44,57 +46,77 @@ def test_require_peaks_below_empty_spectrum():
     spectrum_in = None
     spectrum = require_peaks_below_mz(spectrum_in)
 
-    assert spectrum is None, "Expected different handling of None spectrum."
+    assert spectrum is None, \
+        "Expected different handling of None spectrum."
 
 
 def test_spectrum_processing_minimal_default():
     spectrum_in = Spectrum(mz=np.array([110, 220, 330, 440], dtype="float"),
-                           intensities=np.array([10, 1, 10, 100], dtype="float"))
+                           intensities=np.array([10, 1, 10, 100],
+                                                dtype="float"))
     spectrum = spectrum_processing_minimal(spectrum_in)
 
     assert spectrum is None, \
-        "Expected None because the number of peaks (4) is less than the default threshold (10)."
+        "Expected None because the number of peaks (4) is less than the " \
+        "default threshold (10)."
 
 
 def test_spectrum_processing_minimal_set_n_required_and_max_mz():
-    spectrum_in = Spectrum(mz=np.array([5, 110, 220, 330, 399, 440], dtype="float"),
-                           intensities=np.array([10, 10, 1, 10, 20, 100], dtype="float"))
-    spectrum = spectrum_processing_minimal(spectrum_in, n_required_below_mz=4, max_mz_required=400)
+    spectrum_in = Spectrum(mz=np.array([5, 110, 220, 330, 399, 440],
+                                       dtype="float"),
+                           intensities=np.array([10, 10, 1, 10, 20, 100],
+                                                dtype="float"))
+    spectrum = spectrum_processing_minimal(spectrum_in, n_required_below_mz=4,
+                                           max_mz_required=400)
 
-    assert np.all(spectrum.peaks.mz == spectrum_in.peaks.mz[1:]), "Expected different m/z values"
-    assert np.all(spectrum.peaks.intensities == np.array([0.1 , 0.01, 0.1 , 0.2 , 1.  ])), \
+    assert np.all(spectrum.peaks.mz == spectrum_in.peaks.mz[1:]), \
+        "Expected different m/z values"
+    assert np.all(spectrum.peaks.intensities ==
+                  np.array([0.1, 0.01, 0.1, 0.2, 1.])),\
         "Expected different intensities"
 
 
 def test_spectrum_processing_minimal_set_n_required_intensity_from():
-    spectrum_in = Spectrum(mz=np.array([5, 110, 220, 330, 440], dtype="float"),
-                           intensities=np.array([10, 10, 0.1, 10, 101], dtype="float"))
-    spectrum = spectrum_processing_minimal(spectrum_in, n_required_below_mz=4)
+    spectrum_in = Spectrum(mz=np.array([5, 110, 220, 330, 440],
+                                       dtype="float"),
+                           intensities=np.array([10, 10, 0.1, 10, 101],
+                                                dtype="float"))
+    spectrum = spectrum_processing_minimal(spectrum_in,
+                                           n_required_below_mz=4)
 
     assert spectrum is None, \
-        "Expected None because 1 peak has m/z > max_mz_required and 1 peak has intensity < intensity_from"
+        "Expected None because 1 peak has m/z > max_mz_required and 1 peak " \
+        "has intensity < intensity_from"
 
 
 def test_spectrum_processing_s2v():
     """Test processing an individual spectrum with spectrum_processing_s2v"""
-    spectrum_in = Spectrum(mz=np.array([5, 110, 220, 330, 440], dtype="float"),
-                           intensities=np.array([0.1, 0.2, 0.1, 1, 0.5], dtype="float"),
+    spectrum_in = Spectrum(mz=np.array([5, 110, 220, 330, 440],
+                                       dtype="float"),
+                           intensities=np.array([0.1, 0.2, 0.1, 1, 0.5],
+                                                dtype="float"),
                            metadata={"parent_mass": 250.0,
                                      "precursor_mz": 240.0})
     spectrum = spectrum_processing_s2v(spectrum_in)
     assert isinstance(spectrum, Spectrum), "Expected output to be Spectrum."
-    assert spectrum.peaks == spectrum_in.peaks, "Expected spectrum peaks to be unchanged by function"
-    assert np.all(spectrum.losses.mz == np.array([ 20., 130.])), "Expected other losses"
+    assert spectrum.peaks == spectrum_in.peaks, \
+        "Expected spectrum peaks to be unchanged by function"
+    assert np.all(spectrum.losses.mz == np.array([20., 130.])), \
+        "Expected other losses"
 
 
 # TODO: uncomment once matchms n_max issue is fixed (#177 in matchms)
 # def test_spectrum_processing_s2v_set_n_max():
 #     """Test processing an individual spectrum with spectrum_processing_s2v"""
-#     spectrum_in = Spectrum(mz=np.array([5, 110, 220, 330, 440], dtype="float"),
-#                            intensities=np.array([0.1, 0.2, 0.1, 1, 0.5], dtype="float"),
+#     spectrum_in = Spectrum(mz=np.array([5, 110, 220, 330, 440],
+#                                        dtype="float"),
+#                            intensities=np.array([0.1, 0.2, 0.1, 1, 0.5],
+#                                                 dtype="float"),
 #                            metadata={"parent_mass": 250.0,
 #                                      "precursor_mz": 240.0})
 #     spectrum = spectrum_processing_s2v(spectrum_in, n_max=4)
 #     assert isinstance(spectrum, Spectrum), "Expected output to be Spectrum."
-#     assert spectrum.peaks == spectrum_in.peaks[1:], "Expected only the first peak to be removed"
-#     assert np.all(spectrum.losses.mz == np.array([ 20., 130.])), "Expected other losses"
+#     assert spectrum.peaks == spectrum_in.peaks[1:], \
+#         "Expected only the first peak to be removed"
+#     assert np.all(spectrum.losses.mz == np.array([ 20., 130.])), \
+#         "Expected other losses"

--- a/tests/test_spectrum_processing.py
+++ b/tests/test_spectrum_processing.py
@@ -57,8 +57,17 @@ def test_spectrum_processing_minimal_default():
 def test_spectrum_processing_minimal_set_n_required():
     spectrum_in = Spectrum(mz=np.array([5, 110, 220, 330, 440], dtype="float"),
                            intensities=np.array([10, 10, 1, 10, 100], dtype="float"))
-    spectrum = spectrum_processing_minimal(spectrum_in, n_required_below_1000=4)
+    spectrum = spectrum_processing_minimal(spectrum_in, n_required_below_1000=4, max_mz_required=400)
 
     assert np.all(spectrum.peaks.mz == spectrum_in.peaks.mz[1:]), "Expected m/z values to be unchanged"
     assert np.all(spectrum.peaks.intensities == np.array([0.1 , 0.01, 0.1 , 1.  ])), \
         "Expected different, normalized intensities"
+
+
+def test_spectrum_processing_minimal_set_n_required_intensity_from():
+    spectrum_in = Spectrum(mz=np.array([5, 110, 220, 330, 440], dtype="float"),
+                           intensities=np.array([10, 10, 0.1, 10, 101], dtype="float"))
+    spectrum = spectrum_processing_minimal(spectrum_in, n_required_below_1000=4)
+
+    assert None, \
+        "Expected None because 1 peak has m/z > max_mz_required and 1 peak has intensity < intensity_from"


### PR DESCRIPTION
Add necessary filtering functions (or restructure the ones we already had). Aim is to address #60.

- minimal processing is now done via `spectrum_processing_minimal()`.
- further processing to prepare for Spec2Vec calculation (but should also work for all other scores): `spectrum_processing_s2v()`

Bit unclear, but this also contains a refactored CI workflow including sonarcloud which I just added to the main branch.