### PR TITLE
Improve library files creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,61 @@ ms2library = create_library_object_from_one_dir(ms2query_library_files_directory
 run_complete_folder(ms2library, ms2_spectra_directory)
 
 ```
+
+## Create your own library
+If you would like to create a library for your own library. You can run the following code:
+
+It is important that the library spectra are annotated with smiles, inchi's or inchikeys in the metadata otherwise they
+are not included in the library. 
+
+Fill in the blank spots with the file locations.
+For downloading a s2v model and ms2ds model see above in "Run MS2Query"
+
+```python
+from ms2query.library_files_creator import LibraryFilesCreator
+from ms2query.utils import convert_files_to_matchms_spectrum_objects
+spectrum_file_location = 
+library_spectra = convert_files_to_matchms_spectrum_objects(spectrum_file_location)
+# Fill in the missing values:
+library_creator = LibraryFilesCreator(library_spectra, 
+                                      output_directory=, 
+                                      ion_mode="positive",
+                                      ms2ds_model_file_name=,
+                                      s2v_model_file_name=,)
+library_creator.clean_up_smiles_inchi_and_inchikeys(do_pubchem_lookup=True)
+library_creator.clean_peaks_and_normalise_intensities_spectra()
+library_creator.remove_not_fully_annotated_spectra()
+library_creator.calculate_tanimoto_scores()
+library_creator.create_all_library_files()
+```
+
+To run MS2Query on your own created library run (again fill in the blanks).
+For the SQLite file, S2V embeddings file and the ms2ds embeddings file. The files just calculated by you should be used.
+For the other files the files downloaded from zenodo (see "run MS2Query") should be used. 
+The results will be returned as csv files in a results directory. 
+```python
+from ms2query.run_ms2query import download_default_models, default_library_file_base_names, run_complete_folder
+from ms2query.ms2library import MS2Library
+
+# Define the folder in which your query spectra are stored.
+# Accepted formats are: "mzML", "json", "mgf", "msp", "mzxml", "usi" or a pickled matchms object. 
+ms2_spectra_directory = "specify_directory"
+
+# Create a MS2Library object
+ms2library = MS2Library(sqlite_file_name= ,
+                        s2v_model_file_name= ,
+                        ms2ds_model_file_name= ,
+                        pickled_s2v_embeddings_file_name= ,
+                        pickled_ms2ds_embeddings_file_name= ,
+                        ms2query_model_file_name= ,
+                        classifier_csv_file_name= ,
+                        )
+
+# Run library search and analog search on your files.
+run_complete_folder(ms2library, ms2_spectra_directory)
+```
+
+
 ## Documentation for developers
 ### Prepare environmnent
 We recommend to create an Anaconda environment with

--- a/README.md
+++ b/README.md
@@ -95,14 +95,14 @@ For downloading a s2v model and ms2ds model see above in "Run MS2Query"
 ```python
 from ms2query.library_files_creator import LibraryFilesCreator
 from ms2query.utils import convert_files_to_matchms_spectrum_objects
-spectrum_file_location = 
+spectrum_file_location = # The file location of the library spectra
 library_spectra = convert_files_to_matchms_spectrum_objects(spectrum_file_location)
 # Fill in the missing values:
 library_creator = LibraryFilesCreator(library_spectra, 
-                                      output_directory=, 
+                                      output_base_filename=, # For instance "data/library_data/all_GNPS_positive_mode_"
                                       ion_mode="positive",
-                                      ms2ds_model_file_name=,
-                                      s2v_model_file_name=,)
+                                      ms2ds_model_file_name=, # The file location of the ms2ds model
+                                      s2v_model_file_name=,) # The file location of the s2v model
 library_creator.clean_up_smiles_inchi_and_inchikeys(do_pubchem_lookup=True)
 library_creator.clean_peaks_and_normalise_intensities_spectra()
 library_creator.remove_not_fully_annotated_spectra()

--- a/ms2query/create_sqlite_database.py
+++ b/ms2query/create_sqlite_database.py
@@ -3,7 +3,6 @@ from typing import Dict, List
 import pandas as pd
 from matchms import Spectrum
 from tqdm import tqdm
-from ms2query.utils import load_pickled_file
 
 
 def make_sqlfile_wrapper(sqlite_file_name: str,

--- a/ms2query/create_sqlite_database.py
+++ b/ms2query/create_sqlite_database.py
@@ -7,7 +7,7 @@ from ms2query.utils import load_pickled_file
 
 
 def make_sqlfile_wrapper(sqlite_file_name: str,
-                         tanimoto_scores_pickled_dataframe_file: str,
+                         tanimoto_scores: pd.DataFrame,
                          list_of_spectra: List[Spectrum],
                          columns_dict: Dict[str, str] = None,
                          progress_bars: bool = True):
@@ -38,7 +38,7 @@ def make_sqlfile_wrapper(sqlite_file_name: str,
     """
     initialize_tables(sqlite_file_name, additional_metadata_columns_dict=columns_dict)
     fill_spectrum_data_table(sqlite_file_name, list_of_spectra, progress_bar=progress_bars)
-    fill_inchikeys_table(sqlite_file_name, tanimoto_scores_pickled_dataframe_file, list_of_spectra,
+    fill_inchikeys_table(sqlite_file_name, tanimoto_scores, list_of_spectra,
                          progress_bars=progress_bars)
 
 
@@ -161,7 +161,7 @@ def fill_spectrum_data_table(sqlite_file_name: str,
 
 
 def fill_inchikeys_table(sqlite_file_name: str,
-                         tanimoto_scores_pickled_dataframe_file: str,
+                         tanimoto_scores : pd.DataFrame,
                          list_of_spectra: List[Spectrum],
                          progress_bars: bool = True):
     """Fills the inchikeys table with Inchikeys, spectrum_ids_belonging_to_inchikey and closest related inchikeys
@@ -179,17 +179,15 @@ def fill_inchikeys_table(sqlite_file_name: str,
         If True progress bars will show the progress of the different steps
         in the process.
     """
-    tanimoto_df = load_pickled_file(tanimoto_scores_pickled_dataframe_file)
-
     # Get spectra belonging to each inchikey14
     spectra_belonging_to_inchikey14 = \
         get_spectra_belonging_to_inchikey14(list_of_spectra)
 
-    inchikeys_order = tanimoto_df.index
+    inchikeys_order = tanimoto_scores.index
 
     # Get closest related inchikey14s for each inchikey14
     closest_related_inchikey14s = \
-        get_closest_related_inchikey14s(tanimoto_df, inchikeys_order)
+        get_closest_related_inchikey14s(tanimoto_scores, inchikeys_order)
 
     conn = sqlite3.connect(sqlite_file_name)
     cur = conn.cursor()

--- a/ms2query/library_files_creator.py
+++ b/ms2query/library_files_creator.py
@@ -177,6 +177,12 @@ class LibraryFilesCreator:
                 "Tanimoto scores file does not exists" \
             # Todo automatically create tanimoto scores
 
+        self.create_sqlite_file(tanimoto_scores_file_name)
+        self.store_s2v_embeddings(s2v_model_file_name)
+        self.store_ms2ds_embeddings(ms2ds_model_file_name)
+
+    def create_sqlite_file(self,
+                           tanimoto_scores_file_name):
         make_sqlfile_wrapper(
             self.settings["output_file_sqlite"],
             tanimoto_scores_file_name,
@@ -184,9 +190,6 @@ class LibraryFilesCreator:
             columns_dict={"precursor_mz": "REAL"},
             progress_bars=self.settings["progress_bars"],
         )
-
-        self.store_s2v_embeddings(s2v_model_file_name)
-        self.store_ms2ds_embeddings(ms2ds_model_file_name)
 
     def store_ms2ds_embeddings(self,
                                ms2ds_model_file_name):

--- a/ms2query/library_files_creator.py
+++ b/ms2query/library_files_creator.py
@@ -27,18 +27,21 @@ class LibraryFilesCreator:
 
     .. code-block:: python
 
-        from ms2query import LibraryFilesCreator
-
-        # Initiate Creator
-        library_creator = LibraryFilesCreator(
-            spectrums_file,
-            output_file_sqlite="... folder and file name base...",
-            'tanimoto_scores.pickle',
-            'ms2ds_model.hdf5',
-            'spec2vec_model.model'
-            progress_bars=True)
-        #
-        library_creator.create_all_library_files()
+    from ms2query.library_files_creator import LibraryFilesCreator
+    from ms2query.utils import convert_files_to_matchms_spectrum_objects
+    spectrum_file_location =
+    library_spectra = convert_files_to_matchms_spectrum_objects(spectrum_file_location)
+    # Fill in the missing values:
+    library_creator = LibraryFilesCreator(library_spectra,
+                                          output_directory=,
+                                          ion_mode="positive",
+                                          ms2ds_model_file_name=,
+                                          s2v_model_file_name=,)
+    library_creator.clean_up_smiles_inchi_and_inchikeys(do_pubchem_lookup=True)
+    library_creator.clean_peaks_and_normalise_intensities_spectra()
+    library_creator.remove_not_fully_annotated_spectra()
+    library_creator.calculate_tanimoto_scores()
+    library_creator.create_all_library_files()
 
     """
     def __init__(self,

--- a/ms2query/library_files_creator.py
+++ b/ms2query/library_files_creator.py
@@ -11,7 +11,7 @@ from tqdm import tqdm
 from ms2query.create_sqlite_database import make_sqlfile_wrapper
 from ms2query.spectrum_processing import (create_spectrum_documents,
                                           minimal_processing_multiple_spectra)
-from ms2query.utils import load_pickled_file
+from ms2query.utils import load_pickled_file, convert_files_to_matchms_spectrum_objects
 
 
 class LibraryFilesCreator:
@@ -155,7 +155,7 @@ class LibraryFilesCreator:
             The file name of a pickled file containing a list of spectra.
         """
         # Loads the spectra from a pickled file
-        list_of_spectra = load_pickled_file(pickled_spectra_file_name)
+        list_of_spectra = convert_files_to_matchms_spectrum_objects(pickled_spectra_file_name)
 
         # Does normalization and filtering of spectra
         list_of_spectra = \

--- a/ms2query/library_files_creator.py
+++ b/ms2query/library_files_creator.py
@@ -282,8 +282,8 @@ class LibraryFilesCreator:
         fingerprint_spectra = []
         for spectrum in tqdm(spectra_with_most_frequent_inchi_per_inchikey):
             spectrum_with_fingerprint = add_fingerprint(spectrum,
-                                                       fingerprint_type="daylight",
-                                                       nbits=2048)
+                                                        fingerprint_type="daylight",
+                                                        nbits=2048)
             fingerprint_spectra.append(spectrum_with_fingerprint)
 
             assert spectrum_with_fingerprint.get("fingerprint") is not None, \
@@ -297,6 +297,4 @@ class LibraryFilesCreator:
                                        index=inchikeys14_unique,
                                        columns=inchikeys14_unique)
         self.tanimoto_scores = tanimoto_scores
-        # pickle.dump(results,
-        #             open(os.path.join(path_data, "GNPS_15_12_2021_pos_tanimoto_scores.pickle"), "wb"))
-
+        return self.tanimoto_scores

--- a/ms2query/library_files_creator.py
+++ b/ms2query/library_files_creator.py
@@ -145,8 +145,7 @@ class LibraryFilesCreator:
     def create_all_library_files(self,
                                  tanimoto_scores_file_name: str,
                                  ms2ds_model_file_name: str,
-                                 s2v_model_file_name: str,
-                                 calculate_new_tanimoto_scores: bool = False):
+                                 s2v_model_file_name: str):
         """Creates files with embeddings and a sqlite file with spectra data
 
         Args:
@@ -166,16 +165,8 @@ class LibraryFilesCreator:
         """
         assert os.path.exists(ms2ds_model_file_name), "ms2deepscore model file does not exist"
         assert os.path.exists(s2v_model_file_name), "spec2vec model file does not exist"
-
-        if calculate_new_tanimoto_scores:
-            assert not os.path.exists(tanimoto_scores_file_name),\
-                "Tanimoto scores file already exists, " \
-                "to use a file with already calculated tanimoto scores, " \
-                "set calculate_new_tanimoto_scores to False"
-        else:
-            assert os.path.exists(tanimoto_scores_file_name),\
-                "Tanimoto scores file does not exists" \
-            # Todo automatically create tanimoto scores
+        assert os.path.exists(tanimoto_scores_file_name),\
+            "Tanimoto scores file does not exists" \
 
         self.create_sqlite_file(tanimoto_scores_file_name)
         self.store_s2v_embeddings(s2v_model_file_name)

--- a/ms2query/library_files_creator.py
+++ b/ms2query/library_files_creator.py
@@ -27,21 +27,21 @@ class LibraryFilesCreator:
 
     .. code-block:: python
 
-    from ms2query.library_files_creator import LibraryFilesCreator
-    from ms2query.utils import convert_files_to_matchms_spectrum_objects
-    spectrum_file_location =
-    library_spectra = convert_files_to_matchms_spectrum_objects(spectrum_file_location)
-    # Fill in the missing values:
-    library_creator = LibraryFilesCreator(library_spectra,
-                                          output_directory=,
-                                          ion_mode="positive",
-                                          ms2ds_model_file_name=,
-                                          s2v_model_file_name=,)
-    library_creator.clean_up_smiles_inchi_and_inchikeys(do_pubchem_lookup=True)
-    library_creator.clean_peaks_and_normalise_intensities_spectra()
-    library_creator.remove_not_fully_annotated_spectra()
-    library_creator.calculate_tanimoto_scores()
-    library_creator.create_all_library_files()
+        from ms2query.library_files_creator import LibraryFilesCreator
+        from ms2query.utils import convert_files_to_matchms_spectrum_objects
+        spectrum_file_location =
+        library_spectra = convert_files_to_matchms_spectrum_objects(spectrum_file_location)
+        # Fill in the missing values:
+        library_creator = LibraryFilesCreator(library_spectra,
+                                              output_directory=,
+                                              ion_mode="positive",
+                                              ms2ds_model_file_name=,
+                                              s2v_model_file_name=,)
+        library_creator.clean_up_smiles_inchi_and_inchikeys(do_pubchem_lookup=True)
+        library_creator.clean_peaks_and_normalise_intensities_spectra()
+        library_creator.remove_not_fully_annotated_spectra()
+        library_creator.calculate_tanimoto_scores()
+        library_creator.create_all_library_files()
 
     """
     def __init__(self,

--- a/ms2query/library_files_creator.py
+++ b/ms2query/library_files_creator.py
@@ -1,14 +1,14 @@
 import os
+from collections import Counter
 from typing import Dict, List, Union
+import matchms.filtering as msfilters
 import numpy as np
 import pandas as pd
 from gensim.models import Word2Vec
-from collections import Counter
-from matchms.Spectrum import Spectrum
 from matchms import calculate_scores
 from matchms.filtering import add_fingerprint
 from matchms.similarity import FingerprintSimilarity
-import matchms.filtering as msfilters
+from matchms.Spectrum import Spectrum
 from matchmsextras.pubchem_lookup import pubchem_metadata_lookup
 from ms2deepscore import MS2DeepScore
 from ms2deepscore.models import load_model as load_ms2ds_model

--- a/ms2query/library_files_creator.py
+++ b/ms2query/library_files_creator.py
@@ -223,7 +223,6 @@ class LibraryFilesCreator:
         print(f"From {len(self.list_of_spectra)} spectra, {len(self.list_of_spectra) - len(fully_annotated_spectra)} are removed since they are not fully annotated")
         self.list_of_spectra = fully_annotated_spectra
 
-
     def clean_peaks_and_normalise_intensities_spectra(self):
         """Cleans library spectra
 
@@ -343,7 +342,8 @@ class LibraryFilesCreator:
         spectra_with_most_frequent_inchi_per_inchikey, inchikeys14_unique = self._select_inchi_for_unique_inchikeys()
         # Add fingerprints
         fingerprint_spectra = []
-        for spectrum in tqdm(spectra_with_most_frequent_inchi_per_inchikey):
+        for spectrum in tqdm(spectra_with_most_frequent_inchi_per_inchikey,
+                             desc="Calculating fingerprints for tanimoto scores"):
             spectrum_with_fingerprint = add_fingerprint(spectrum,
                                                         fingerprint_type="daylight",
                                                         nbits=2048)

--- a/ms2query/library_files_creator.py
+++ b/ms2query/library_files_creator.py
@@ -8,6 +8,8 @@ from matchms.Spectrum import Spectrum
 from matchms import calculate_scores
 from matchms.filtering import add_fingerprint
 from matchms.similarity import FingerprintSimilarity
+import matchms.filtering as msfilters
+from matchmsextras.pubchem_lookup import pubchem_metadata_lookup
 from ms2deepscore import MS2DeepScore
 from ms2deepscore.models import load_model as load_ms2ds_model
 from spec2vec.vector_operations import calc_vector
@@ -43,6 +45,7 @@ class LibraryFilesCreator:
     def __init__(self,
                  spectra_file_name: str,
                  output_base_filename: str,
+                 ion_mode: str = "positive",
                  tanimoto_scores_file_name: str = None,
                  s2v_model_file_name: str = None,
                  ms2ds_model_file_name: str = None,
@@ -82,11 +85,8 @@ class LibraryFilesCreator:
         """
         self.settings = self._set_settings(settings, output_base_filename)
         self._check_for_existing_files()
-
-        # Load in the spectra
-        self.list_of_spectra = \
-            self._load_spectra_and_minimal_processing(
-                spectra_file_name)
+        assert ion_mode in {"positive", "negative"}, "ion_mode should be set to 'positive' or 'negative'"
+        self.ion_mode = ion_mode
 
         # Load in tanimoto scores
         if tanimoto_scores_file_name is None:
@@ -106,6 +106,11 @@ class LibraryFilesCreator:
         else:
             assert os.path.exists(ms2ds_model_file_name), "MS2Deepscore model file does not exists"
             self.ms2ds_model = load_ms2ds_model(ms2ds_model_file_name)
+        # Load in the spectra
+        self.list_of_spectra = convert_files_to_matchms_spectrum_objects(spectra_file_name)
+        self.list_of_spectra = [msfilters.default_filters(s) for s in tqdm(self.list_of_spectra,
+                                                                           desc="Applying default filters to spectra")]
+        self.remove_wrong_ion_modes()
 
     @staticmethod
     def _set_settings(new_settings: Dict[str, Union[str, bool]],
@@ -160,25 +165,76 @@ class LibraryFilesCreator:
             f"The file {self.settings['s2v_embeddings_file_name']} " \
             f"already exists, choose a different output_base_filename"
 
-    def _load_spectra_and_minimal_processing(self,
-                                             pickled_spectra_file_name: str
-                                             ) -> List[Spectrum]:
-        """Loads spectra from pickled file and does minimal processing
+    def clean_up_smiles_inchi_and_inchikeys(self, do_pubchem_lookup):
+        """Uses filters to clean ms2query
 
-        Args:
-        ------
-        pickled_spectra_file_name:
-            The file name of a pickled file containing a list of spectra.
+        do_pubchem_lookup: If true missing information will be searched on pubchem"""
+        def run_metadata_filters(s):
+            # Default filters
+            s = msfilters.derive_adduct_from_name(s)
+            s = msfilters.add_parent_mass(s, estimate_from_adduct=True)
+
+            # Here, undefiend entries will be harmonized (instead of having a huge variation of None,"", "N/A" etc.)
+            s = msfilters.harmonize_undefined_inchikey(s)
+            s = msfilters.harmonize_undefined_inchi(s)
+            s = msfilters.harmonize_undefined_smiles(s)
+
+            # The repair_inchi_inchikey_smiles function will correct misplaced metadata (e.g. inchikeys entered as inchi etc.) and harmonize the entry strings.
+            s = msfilters.repair_inchi_inchikey_smiles(s)
+
+            # Where possible (and necessary, i.e. missing): Convert between smiles, inchi, inchikey to complete metadata. This is done using functions from rdkit.
+            s = msfilters.derive_inchi_from_smiles(s)
+            s = msfilters.derive_smiles_from_inchi(s)
+            s = msfilters.derive_inchikey_from_inchi(s)
+
+            if do_pubchem_lookup:
+                s = pubchem_metadata_lookup(s,
+                                            mass_tolerance=2.0,
+                                            allowed_differences=[(18.03, 0.01),
+                                                                 (18.01, 0.01)],
+                                            name_search_depth=15)
+            return s
+        self.list_of_spectra = [run_metadata_filters(s) for s in tqdm(self.list_of_spectra,
+                                                                      desc="Cleaning metadata library spectra")]
+
+    def remove_wrong_ion_modes(self):
+        spectra_to_keep = []
+        for i, spec in enumerate(tqdm(self.list_of_spectra, desc=f"Selecting {self.ion_mode} mode spectra")):
+            if spec.get("ionmode") == self.ion_mode:
+                spectra_to_keep.append(spec)
+        print(f"From {len(self.list_of_spectra)} spectra, {len(self.list_of_spectra) - len(spectra_to_keep)} are removed since they are not in {self.ion_mode} mode")
+        self.list_of_spectra = spectra_to_keep
+
+    def remove_not_fully_annotated_spectra(self):
+        fully_annotated_spectra = []
+        for spectrum in self.list_of_spectra:
+            inchikey = spectrum.get("inchikey")
+            if inchikey is not None and len(inchikey) > 13:
+                smiles = spectrum.get("smiles")
+                inchi = spectrum.get("inchi")
+                if smiles is not None and len(smiles) > 0:
+                    if inchi is not None and len(inchi) > 0:
+                        fully_annotated_spectra.append(spectrum)
+        self.list_of_spectra = fully_annotated_spectra
+
+    def clean_spectra(self):
+        """Cleans library spectra
+
+        pubchem_lookup:
+
         """
-        # Loads the spectra from a pickled file
-        list_of_spectra = convert_files_to_matchms_spectrum_objects(pickled_spectra_file_name)
+        def normalize_and_filter_peaks(spectrum):
+            spectrum = msfilters.normalize_intensities(spectrum)
+            spectrum = msfilters.select_by_relative_intensity(spectrum, 0.001, 1)
+            spectrum = msfilters.select_by_mz(spectrum, mz_from=0.0, mz_to=1000.0)
+            spectrum = msfilters.reduce_to_number_of_peaks(spectrum, n_max=500)
+            spectrum = msfilters.require_minimum_number_of_peaks(spectrum, n_required=3)
+            return spectrum
 
-        # Does normalization and filtering of spectra
-        list_of_spectra = \
-            minimal_processing_multiple_spectra(
-                list_of_spectra,
-                progress_bar=self.settings["progress_bars"])
-        return list_of_spectra
+        library_spectra = [normalize_and_filter_peaks(s) for s in tqdm(self.list_of_spectra,
+                                                                       desc="Cleaning and filtering peaks library spectra")]
+        library_spectra = [s for s in library_spectra if s is not None]
+        self.list_of_spectra = library_spectra
 
     def create_all_library_files(self):
         """Creates files with embeddings and a sqlite file with spectra data

--- a/ms2query/library_files_creator.py
+++ b/ms2query/library_files_creator.py
@@ -85,6 +85,7 @@ class LibraryFilesCreator:
             If True, a progress bar of the different processes is shown.
             Default = True.
         """
+        # pylint: disable=too-many-arguments
         self.settings = self._set_settings(settings, output_base_filename)
         self._check_for_existing_files()
         assert ion_mode in {"positive", "negative"}, "ion_mode should be set to 'positive' or 'negative'"
@@ -187,7 +188,8 @@ class LibraryFilesCreator:
             # The repair_inchi_inchikey_smiles function will correct misplaced metadata (e.g. inchikeys entered as inchi etc.) and harmonize the entry strings.
             s = msfilters.repair_inchi_inchikey_smiles(s)
 
-            # Where possible (and necessary, i.e. missing): Convert between smiles, inchi, inchikey to complete metadata. This is done using functions from rdkit.
+            # Where possible (and necessary, i.e. missing): Convert between smiles, inchi, inchikey to complete metadata.
+            # This is done using functions from rdkit.
             s = msfilters.derive_inchi_from_smiles(s)
             s = msfilters.derive_smiles_from_inchi(s)
             s = msfilters.derive_inchikey_from_inchi(s)
@@ -204,10 +206,11 @@ class LibraryFilesCreator:
 
     def remove_wrong_ion_modes(self):
         spectra_to_keep = []
-        for i, spec in enumerate(tqdm(self.list_of_spectra, desc=f"Selecting {self.ion_mode} mode spectra")):
+        for spec in tqdm(self.list_of_spectra, desc=f"Selecting {self.ion_mode} mode spectra"):
             if spec.get("ionmode") == self.ion_mode:
                 spectra_to_keep.append(spec)
-        print(f"From {len(self.list_of_spectra)} spectra, {len(self.list_of_spectra) - len(spectra_to_keep)} are removed since they are not in {self.ion_mode} mode")
+        print(f"From {len(self.list_of_spectra)} spectra, "
+              f"{len(self.list_of_spectra) - len(spectra_to_keep)} are removed since they are not in {self.ion_mode} mode")
         self.list_of_spectra = spectra_to_keep
 
     def remove_not_fully_annotated_spectra(self):
@@ -220,7 +223,8 @@ class LibraryFilesCreator:
                 if smiles is not None and len(smiles) > 0:
                     if inchi is not None and len(inchi) > 0:
                         fully_annotated_spectra.append(spectrum)
-        print(f"From {len(self.list_of_spectra)} spectra, {len(self.list_of_spectra) - len(fully_annotated_spectra)} are removed since they are not fully annotated")
+        print(f"From {len(self.list_of_spectra)} spectra, "
+              f"{len(self.list_of_spectra) - len(fully_annotated_spectra)} are removed since they are not fully annotated")
         self.list_of_spectra = fully_annotated_spectra
 
     def clean_peaks_and_normalise_intensities_spectra(self):

--- a/ms2query/library_files_creator.py
+++ b/ms2query/library_files_creator.py
@@ -28,15 +28,16 @@ class LibraryFilesCreator:
         library_creator = LibraryFilesCreator(
             spectrums_file,
             output_file_sqlite="... folder and file name base...",
+            'tanimoto_scores.pickle',
+            'ms2ds_model.hdf5',
+            'spec2vec_model.model'
             progress_bars=True)
         #
-        library_creator.create_all_library_files('tanimoto_scores.pickle',
-                                                 'ms2ds_model.hdf5',
-                                                 'spec2vec_model.model')
+        library_creator.create_all_library_files()
 
     """
     def __init__(self,
-                 pickled_spectra_file_name: str,
+                 spectra_file_name: str,
                  output_base_filename: str,
                  tanimoto_scores_file_name: str = None,
                  s2v_model_file_name: str = None,
@@ -46,14 +47,24 @@ class LibraryFilesCreator:
 
         Parameters
         ----------
-        pickled_spectra_file_name:
-            File name of a pickled file containing spectrum objects.
+        spectra_file_name:
+            File name of a file containing mass spectra. Accepted file types are: "mzML", "json", "mgf", "msp",
+        "mzxml", "usi" or "pickle"
         output_base_filename:
             The file name used as base for new files that are created.
             The following extensions are added to the output_base_filename
             For sqlite file: ".sqlite"
             For ms2ds_embeddings: "_ms2ds_embeddings.pickle"
             For s2v_embeddings: "_s2v_embeddings.pickle"
+        tanimoto_scores_file_name:
+            File name of a pickled file containing a dataframe with tanimoto
+            scores. If self.calculate_new_tanimoto_scores = True, this will
+            be the file name of a new file in which the tanimoto scores will
+            be stored.
+        s2v_model_file_name:
+            file name of a s2v model
+        ms2ds_model_file_name:
+            File name of a ms2ds model
 
         **settings:
             The following optional parameters can be defined.
@@ -70,7 +81,7 @@ class LibraryFilesCreator:
         # Load in the spectra
         self.list_of_spectra = \
             self._load_spectra_and_minimal_processing(
-                pickled_spectra_file_name)
+                spectra_file_name)
 
         # Load in tanimoto scores
         if tanimoto_scores_file_name is None:
@@ -166,21 +177,6 @@ class LibraryFilesCreator:
 
     def create_all_library_files(self):
         """Creates files with embeddings and a sqlite file with spectra data
-
-        Args:
-        ------
-        tanimoto_scores_file_name:
-            File name of a pickled file containing a dataframe with tanimoto
-            scores. If self.calculate_new_tanimoto_scores = True, this will
-            be the file name of a new file in which the tanimoto scores will
-            be stored.
-        ms2ds_model_file_name:
-            File name of a ms2ds model
-        s2v_model_file_name:
-            file name of a s2v model
-        calculate_new_tanimoto_scores:
-            If True new tanimoto scores will be calculated and stored in
-            tanimoto_scores_file_name.
         """
         self.create_sqlite_file()
         self.store_s2v_embeddings()
@@ -199,18 +195,8 @@ class LibraryFilesCreator:
     def store_ms2ds_embeddings(self):
         """Creates a pickled file with embeddings scores for spectra
 
-        A dataframe with as index the spectrum_ids and as columns the indexes
+        A dataframe with as index randomly generated spectrum indexes and as columns the indexes
         of the vector is converted to pickle.
-
-        Args:
-        ------
-        spectrum_list:
-            Spectra for which embeddings should be calculated.
-        ms2ds_model_file_name:
-            File name for a SiameseModel that is used to calculate the
-            embeddings.
-        new_pickled_embeddings_file_name:
-            The file name in which the pickled dataframe is stored.
         """
         assert not os.path.exists(self.settings[
                                       'ms2ds_embeddings_file_name']), \
@@ -229,15 +215,8 @@ class LibraryFilesCreator:
     def store_s2v_embeddings(self):
         """Creates and stored a dataframe with embeddings as pickled file
 
-        A dataframe with as index the spectrum_ids and as columns the indexes
+        A dataframe with as index randomly generated spectrum indexes and as columns the indexes
         of the vector is converted to pickle.
-
-        Args:
-        ------
-        s2v_model_file_name:
-            File name to load spec2vec model, 3 files are expected, with the
-             extension .model, .model.trainables.syn1neg.npy and
-             .model.wv.vectors.npy, together containing a Spec2Vec model,
         """
         assert not os.path.exists(self.settings[
             "s2v_embeddings_file_name"]), \

--- a/ms2query/spectrum_processing.py
+++ b/ms2query/spectrum_processing.py
@@ -6,11 +6,7 @@ adjusting the spectrum peaks (m/z and intensities).
 from typing import Dict, List, Union
 import numpy as np
 from matchms import Spectrum
-from matchms.filtering import (add_losses, add_retention_index,
-                               add_retention_time, default_filters,
-                               normalize_intensities,
-                               reduce_to_number_of_peaks, require_precursor_mz,
-                               select_by_intensity, select_by_mz)
+import matchms.filtering as msfilters
 from matchms.typing import SpectrumType
 from spec2vec import SpectrumDocument
 from tqdm import tqdm
@@ -19,9 +15,9 @@ from tqdm import tqdm
 def clean_metadata(spectrum_list: List[SpectrumType]):
     spectra_cleaned_metadata = []
     for i, s in enumerate(spectrum_list):
-        s = default_filters(s)
-        s = add_retention_index(s)
-        s = add_retention_time(s)
+        s = msfilters.default_filters(s)
+        s = msfilters.add_retention_index(s)
+        s = msfilters.add_retention_time(s)
         s.set("spectrum_nr", i+1)
         spectra_cleaned_metadata.append(s)
     return spectra_cleaned_metadata
@@ -87,17 +83,17 @@ def spectrum_processing_minimal(spectrum: SpectrumType,
         contains sufficient peaks to be considered.
     """
     settings = set_minimal_processing_defaults(**settings)
-    spectrum = normalize_intensities(spectrum)
-    spectrum = select_by_intensity(spectrum,
+    spectrum = msfilters.normalize_intensities(spectrum)
+    spectrum = msfilters.select_by_intensity(spectrum,
                                    intensity_from=settings["intensity_from"])
-    spectrum = select_by_mz(spectrum,
+    spectrum = msfilters.select_by_mz(spectrum,
                             mz_from=settings["mz_from"],
                             mz_to=np.inf)
     spectrum = require_peaks_below_mz(
         spectrum,
         n_required=settings["n_required_below_mz"],
         max_mz=settings["max_mz_required"])
-    spectrum = require_precursor_mz(spectrum)
+    spectrum = msfilters.require_precursor_mz(spectrum)
     return spectrum
 
 
@@ -175,15 +171,15 @@ def spectrum_processing_s2v(spectrum: SpectrumType,
         Maximum allowed m/z value for losses. Default is 1000.0.
     """
     settings = set_spec2vec_defaults(**settings)
-    spectrum = select_by_mz(spectrum,
+    spectrum = msfilters.select_by_mz(spectrum,
                             mz_from=settings["mz_from"],
                             mz_to=settings["mz_to"])
-    spectrum = reduce_to_number_of_peaks(
+    spectrum = msfilters.reduce_to_number_of_peaks(
         spectrum,
         n_required=settings["n_required"],
         n_max=settings["n_max"])
 
-    spectrum = add_losses(spectrum,
+    spectrum = msfilters.add_losses(spectrum,
                           loss_mz_from=settings["loss_mz_from"],
                           loss_mz_to=settings["loss_mz_to"])
     assert spectrum is not None, \

--- a/ms2query/spectrum_processing.py
+++ b/ms2query/spectrum_processing.py
@@ -4,9 +4,9 @@ into account here. Processing here hence refers to inspecting, filtering,
 adjusting the spectrum peaks (m/z and intensities).
 """
 from typing import Dict, List, Union
+import matchms.filtering as msfilters
 import numpy as np
 from matchms import Spectrum
-import matchms.filtering as msfilters
 from matchms.typing import SpectrumType
 from spec2vec import SpectrumDocument
 from tqdm import tqdm

--- a/ms2query/utils.py
+++ b/ms2query/utils.py
@@ -66,8 +66,6 @@ def convert_files_to_matchms_spectrum_objects(file_name
     if file_extension == ".usi":
         return list(importing.load_from_usi(file_name))
     if file_extension == ".pickle":
-        return load_pickled_file(file_name)
-    if file_extension == ".pickle":
         spectra = load_pickled_file(file_name)
         assert isinstance(spectra, list), "Expected list of spectra"
         assert isinstance(spectra[0], Spectrum), "Expected list of spectra"

--- a/ms2query/utils.py
+++ b/ms2query/utils.py
@@ -67,8 +67,12 @@ def convert_files_to_matchms_spectrum_objects(file_name
         return list(importing.load_from_usi(file_name))
     if file_extension == ".pickle":
         return load_pickled_file(file_name)
-    print(f"File extension of file: {file_name} is not recognized")
-    return None
+    if file_extension == ".pickle":
+        spectra = load_pickled_file(file_name)
+        assert isinstance(spectra, list), "Expected list of spectra"
+        assert isinstance(spectra[0], Spectrum), "Expected list of spectra"
+        return spectra
+    assert False, f"File extension of file: {file_name} is not recognized"
 
 
 def add_unknown_charges_to_spectra(spectrum_list: List[Spectrum],

--- a/notebooks/GNPS_15_12_2021/data_processing_and_training_models/7_create_library_files.py
+++ b/notebooks/GNPS_15_12_2021/data_processing_and_training_models/7_create_library_files.py
@@ -1,21 +1,22 @@
-import os
-from ms2query.library_files_creator import LibraryFilesCreator
+# Deprecated use version 0.3.3 or older
 
-
-file_date = "15_12_2021"
-path_data = "C:\\HSD\\OneDrive - Hochschule Düsseldorf\\Data\\ms2query"
-path_library = os.path.join(path_data, "library_gnps_15_12")
-
-
-file_creator = LibraryFilesCreator(os.path.join(path_data,
-                                                f"GNPS_{file_date}_pos_train.pickle"),
-                                   os.path.join(path_library,
-                                                f"library_GNPS_{file_date}"))
-
-file_creator.create_all_library_files(os.path.join(path_data,
-                                                   f"GNPS_{file_date}_pos_tanimoto_scores.pickle"),
-                                      os.path.join(path_data,
-                                                   f"trained_models/ms2ds_GNPS_{file_date}.hdf5"),
-                                      os.path.join(path_data,
-                                                   f"trained_models/spec2vec_model_GNPS_{file_date}.model")
-                                      )
+# import os
+# from ms2query.library_files_creator import LibraryFilesCreator
+#
+#
+# file_date = "15_12_2021"
+# path_data = "C:\\HSD\\OneDrive - Hochschule Düsseldorf\\Data\\ms2query"
+# path_library = os.path.join(path_data, "library_gnps_15_12")
+#
+# file_creator = LibraryFilesCreator(os.path.join(path_data,
+#                                                 f"GNPS_{file_date}_pos_train.pickle"),
+#                                    os.path.join(path_library,
+#                                                 f"library_GNPS_{file_date}"))
+#
+# file_creator.create_all_library_files(os.path.join(path_data,
+#                                                    f"GNPS_{file_date}_pos_tanimoto_scores.pickle"),
+#                                       os.path.join(path_data,
+#                                                    f"trained_models/ms2ds_GNPS_{file_date}.hdf5"),
+#                                       os.path.join(path_data,
+#                                                    f"trained_models/spec2vec_model_GNPS_{file_date}.model")
+#                                       )

--- a/notebooks/GNPS_15_12_2021/data_processing_and_training_models/negative_mode/7_neg_create_library_files.py
+++ b/notebooks/GNPS_15_12_2021/data_processing_and_training_models/negative_mode/7_neg_create_library_files.py
@@ -1,21 +1,23 @@
-import os
-from ms2query.library_files_creator import LibraryFilesCreator
+# Deprecated use version 0.3.3 or older
 
-
-file_date = "15_12_2021"
-path_root = os.path.dirname(os.getcwd())
-path_data = os.path.join(path_root, "../../../data/libraries_and_models/gnps_15_12_2021/in_between_files")
-path_library = os.path.join(path_data, "../negative_mode_models")
-
-file_creator = LibraryFilesCreator(os.path.join(path_data,
-                                                f"GNPS_{file_date}_neg_train.pickle"),
-                                   os.path.join(path_library,
-                                                f"neg_library_GNPS_{file_date}"))
-
-file_creator.create_all_library_files(os.path.join(path_data,
-                                                   f"GNPS_{file_date}_neg_tanimoto_scores.pickle"),
-                                      os.path.join(path_library,
-                                                   f"ms2ds_GNPS_{file_date}.hdf5"),
-                                      os.path.join(path_library,
-                                                   f"neg_mode_spec2vec_model_GNPS_{file_date}.model")
-                                      )
+# import os
+# from ms2query.library_files_creator import LibraryFilesCreator
+#
+#
+# file_date = "15_12_2021"
+# path_root = os.path.dirname(os.getcwd())
+# path_data = os.path.join(path_root, "../../../data/libraries_and_models/gnps_15_12_2021/in_between_files")
+# path_library = os.path.join(path_data, "../negative_mode_models")
+#
+# file_creator = LibraryFilesCreator(os.path.join(path_data,
+#                                                 f"GNPS_{file_date}_neg_train.pickle"),
+#                                    os.path.join(path_library,
+#                                                 f"neg_library_GNPS_{file_date}"))
+#
+# file_creator.create_all_library_files(os.path.join(path_data,
+#                                                    f"GNPS_{file_date}_neg_tanimoto_scores.pickle"),
+#                                       os.path.join(path_library,
+#                                                    f"ms2ds_GNPS_{file_date}.hdf5"),
+#                                       os.path.join(path_library,
+#                                                    f"neg_mode_spec2vec_model_GNPS_{file_date}.model")
+#                                       )

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,10 @@ setup(
         "scikit-learn",
         "ms2deepscore",
         "gensim>=4.0.0",
-        "pandas>=1.2.5",],
+        "pandas>=1.2.5",
+        "matchmsextras>=0.3.0",
+        "pubchempy", #This is a dependency for matchmsextras, which is missing in setup
+        "tqdm"],
     extras_require={':python_version < "3.8"': ["pickle5",],
                     "dev": ["bump2version",
                             "isort>=5.1.0",

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
                             "sphinx>=3.0.0,!=3.2.0,<4.0.0",
                             "sphinx_rtd_theme",
                             "sphinxcontrib-apidoc",
-                            "yapf",],
+                            "yapf",
+                            "rdkit"],
     }
 )

--- a/tests/test_library_files_creator.py
+++ b/tests/test_library_files_creator.py
@@ -16,8 +16,7 @@ def path_to_general_test_files() -> str:
 def test_set_settings_correct(path_to_general_test_files):
     """Tests if settings are set correctly"""
     test_create_files = LibraryFilesCreator(os.path.join(
-        path_to_general_test_files, '100_test_spectra.pickle'),
-        output_base_filename="test_output_name",
+        path_to_general_test_files, '100_test_spectra.pickle'), output_base_filename="test_output_name",
         progress_bars=False)
 
     assert test_create_files.settings["output_file_sqlite"] == \
@@ -61,12 +60,10 @@ def test_create_all_library_files(tmp_path, path_to_general_test_files):
     """Tests create_all_library_files"""
     base_file_name = os.path.join(tmp_path, '100_test_spectra')
     test_create_files = LibraryFilesCreator(os.path.join(
-        path_to_general_test_files, '100_test_spectra.pickle'),
-        base_file_name,
-        tanimoto_scores_file_name=os.path.join(path_to_general_test_files, '100_test_spectra_tanimoto_scores.pickle',),
+        path_to_general_test_files, '100_test_spectra.pickle'), base_file_name,
+        tanimoto_scores_file_name=os.path.join(path_to_general_test_files, '100_test_spectra_tanimoto_scores.pickle', ),
         s2v_model_file_name=os.path.join(path_to_general_test_files, '100_test_spectra_s2v_model.model'),
-        ms2ds_model_file_name=os.path.join(path_to_general_test_files, 'ms2ds_siamese_210301_5000_500_400.hdf5')
-    )
+        ms2ds_model_file_name=os.path.join(path_to_general_test_files, 'ms2ds_siamese_210301_5000_500_400.hdf5'))
 
     test_create_files.create_all_library_files()
 
@@ -107,8 +104,7 @@ def test_store_ms2ds_embeddings(tmp_path, path_to_general_test_files):
     """Tests store_ms2ds_embeddings"""
     base_file_name = os.path.join(tmp_path, '100_test_spectra')
     test_create_files = LibraryFilesCreator(os.path.join(
-        path_to_general_test_files, '100_test_spectra.pickle'),
-        base_file_name,
+        path_to_general_test_files, '100_test_spectra.pickle'), base_file_name,
         ms2ds_model_file_name=os.path.join(path_to_general_test_files, 'ms2ds_siamese_210301_5000_500_400.hdf5'))
     test_create_files.store_ms2ds_embeddings()
 
@@ -130,8 +126,7 @@ def test_store_s2v_embeddings(tmp_path, path_to_general_test_files):
     """Tests store_ms2ds_embeddings"""
     base_file_name = os.path.join(tmp_path, '100_test_spectra')
     test_create_files = LibraryFilesCreator(os.path.join(
-        path_to_general_test_files, '100_test_spectra.pickle'),
-        base_file_name,
+        path_to_general_test_files, '100_test_spectra.pickle'), base_file_name,
         s2v_model_file_name=os.path.join(path_to_general_test_files, "100_test_spectra_s2v_model.model"))
     test_create_files.store_s2v_embeddings()
 

--- a/tests/test_library_files_creator.py
+++ b/tests/test_library_files_creator.py
@@ -62,10 +62,11 @@ def test_create_all_library_files(tmp_path, path_to_general_test_files):
     base_file_name = os.path.join(tmp_path, '100_test_spectra')
     test_create_files = LibraryFilesCreator(os.path.join(
         path_to_general_test_files, '100_test_spectra.pickle'),
-        base_file_name)
+        base_file_name,
+        tanimoto_scores_file_name=os.path.join(path_to_general_test_files, '100_test_spectra_tanimoto_scores.pickle')
+    )
+
     test_create_files.create_all_library_files(
-        os.path.join(path_to_general_test_files,
-                     '100_test_spectra_tanimoto_scores.pickle'),
         os.path.join(path_to_general_test_files,
                      'ms2ds_siamese_210301_5000_500_400.hdf5'),
         os.path.join(path_to_general_test_files,

--- a/tests/test_library_files_creator.py
+++ b/tests/test_library_files_creator.py
@@ -141,3 +141,16 @@ def test_store_s2v_embeddings(tmp_path, path_to_general_test_files):
     pd.testing.assert_frame_equal(embeddings, expected_embeddings,
                                   check_exact=False,
                                   atol=1e-5)
+
+
+def test_calculate_tanimoto_scores(tmp_path, path_to_general_test_files):
+    base_file_name = os.path.join(tmp_path, '100_test_spectra')
+    test_create_files = LibraryFilesCreator(os.path.join(
+        path_to_general_test_files, '100_test_spectra.pickle'),
+        base_file_name)
+    test_create_files.calculate_tanimoto_scores()
+    result: pd.DataFrame = test_create_files.tanimoto_scores
+    result.sort_index(inplace=True)
+    result.sort_index(1, inplace=True)
+    expected_result = load_pickled_file(path_to_general_test_files + "/100_test_spectra_tanimoto_scores.pickle")
+    pd.testing.assert_frame_equal(result, expected_result, check_exact=False, atol=1e-5)

--- a/tests/test_library_files_creator.py
+++ b/tests/test_library_files_creator.py
@@ -1,9 +1,10 @@
 import os
 import pandas as pd
+import numpy as np
 import pytest
+from matchms import Spectrum
 from ms2query.library_files_creator import LibraryFilesCreator
-from ms2query.utils import load_pickled_file
-from .test_sqlite import check_sqlite_files_are_equal
+from ms2query.utils import load_pickled_file, convert_files_to_matchms_spectrum_objects
 
 
 @pytest.fixture
@@ -14,10 +15,11 @@ def path_to_general_test_files() -> str:
 
 def test_set_settings_correct(path_to_general_test_files):
     """Tests if settings are set correctly"""
-    test_create_files = LibraryFilesCreator(os.path.join(
-        path_to_general_test_files, '100_test_spectra.pickle'), output_base_filename="test_output_name",
-        progress_bars=False)
-
+    library_spectra = convert_files_to_matchms_spectrum_objects(os.path.join(
+        path_to_general_test_files, '100_test_spectra.pickle'))
+    test_create_files = LibraryFilesCreator(library_spectra,
+                                            output_base_filename="test_output_name",
+                                            progress_bars=False)
     assert test_create_files.settings["output_file_sqlite"] == \
            "test_output_name.sqlite", "Expected different output_file_sqlite"
     assert test_create_files.settings["progress_bars"] is False, \
@@ -58,10 +60,11 @@ def test_give_already_used_file_name(tmp_path):
 def test_store_ms2ds_embeddings(tmp_path, path_to_general_test_files):
     """Tests store_ms2ds_embeddings"""
     base_file_name = os.path.join(tmp_path, '100_test_spectra')
-    test_create_files = LibraryFilesCreator(os.path.join(
-        path_to_general_test_files, '100_test_spectra.pickle'), base_file_name,
+    library_spectra = convert_files_to_matchms_spectrum_objects(os.path.join(
+        path_to_general_test_files, '100_test_spectra.pickle'))
+    test_create_files = LibraryFilesCreator(library_spectra, base_file_name,
         ms2ds_model_file_name=os.path.join(path_to_general_test_files, 'ms2ds_siamese_210301_5000_500_400.hdf5'))
-    test_create_files.clean_spectra()
+    test_create_files.clean_peaks_and_normalise_intensities_spectra()
     test_create_files.store_ms2ds_embeddings()
 
     new_embeddings_file_name = base_file_name + "_ms2ds_embeddings.pickle"
@@ -81,10 +84,11 @@ def test_store_ms2ds_embeddings(tmp_path, path_to_general_test_files):
 def test_store_s2v_embeddings(tmp_path, path_to_general_test_files):
     """Tests store_ms2ds_embeddings"""
     base_file_name = os.path.join(tmp_path, '100_test_spectra')
-    test_create_files = LibraryFilesCreator(os.path.join(
-        path_to_general_test_files, '100_test_spectra.pickle'), base_file_name,
+    library_spectra = convert_files_to_matchms_spectrum_objects(os.path.join(
+        path_to_general_test_files, '100_test_spectra.pickle'))
+    test_create_files = LibraryFilesCreator(library_spectra, base_file_name,
         s2v_model_file_name=os.path.join(path_to_general_test_files, "100_test_spectra_s2v_model.model"))
-    test_create_files.clean_spectra()
+    test_create_files.clean_peaks_and_normalise_intensities_spectra()
     test_create_files.store_s2v_embeddings()
 
     new_embeddings_file_name = base_file_name + "_s2v_embeddings.pickle"
@@ -102,12 +106,43 @@ def test_store_s2v_embeddings(tmp_path, path_to_general_test_files):
 
 def test_calculate_tanimoto_scores(tmp_path, path_to_general_test_files):
     base_file_name = os.path.join(tmp_path, '100_test_spectra')
-    test_create_files = LibraryFilesCreator(os.path.join(
-        path_to_general_test_files, '100_test_spectra.pickle'),
-        base_file_name)
+    library_spectra = convert_files_to_matchms_spectrum_objects(os.path.join(
+        path_to_general_test_files, '100_test_spectra.pickle'))
+    test_create_files = LibraryFilesCreator(library_spectra,
+                                            base_file_name)
     test_create_files.calculate_tanimoto_scores()
     result: pd.DataFrame = test_create_files.tanimoto_scores
     result.sort_index(inplace=True)
     result.sort_index(1, inplace=True)
     expected_result = load_pickled_file(path_to_general_test_files + "/100_test_spectra_tanimoto_scores.pickle")
     pd.testing.assert_frame_equal(result, expected_result, check_exact=False, atol=1e-5)
+
+
+def test_clean_library_spectra(tmp_path, path_to_general_test_files):
+    base_file_name = os.path.join(tmp_path, '100_test_spectra')
+
+    spectrum1 = Spectrum(
+        mz=np.array([808.27356, 872.289917, 890.246277, 891.272888, 894.326416, 904.195679,
+                     905.224548, 908.183472, 922.178101, 923.155762], dtype="float"),
+        intensities=np.array([0.11106008, 0.12347332, 0.16352988, 0.17101522, 0.17312992, 0.19262333, 0.21442898,
+                              0.42173288, 0.51071955, 1.], dtype="float"),
+        metadata={'pepmass': (907.0, None), 'spectrumid': 'CCMSLIB00000001760', 'precursor_mz': 907.0,
+                  'smiles': 'CCCC', 'ionmode': "positive"})
+    spectrum2 = Spectrum(
+        mz=np.array([538.003174, 539.217773, 556.030396, 599.352783, 851.380859, 852.370605, 909.424438, 953.396606,
+                     963.686768, 964.524658], dtype="float"),
+        intensities=np.array([0.28046377, 0.28900242, 0.31933114, 0.32199162, 0.34214536, 0.35616456, 0.36216307,
+                              0.41616014, 0.71323034, 1.], dtype="float"),
+        metadata={'pepmass': (928.0, None), 'spectrumid': 'CCMSLIB00000001761', 'precursor_mz': 342.30,
+                  'compound_name': 'sucrose', "ionmode": "positive"})
+    library_spectra = [spectrum1, spectrum2]
+    test_create_files = LibraryFilesCreator(library_spectra,
+                                            base_file_name,
+                                            ion_mode="positive")
+    test_create_files.clean_peaks_and_normalise_intensities_spectra()
+    test_create_files.clean_up_smiles_inchi_and_inchikeys(True)
+    test_create_files.remove_not_fully_annotated_spectra()
+    filtered_spectra = test_create_files.list_of_spectra
+    print(filtered_spectra[0].metadata)
+    print(filtered_spectra[1].metadata)
+    assert False

--- a/tests/test_library_files_creator.py
+++ b/tests/test_library_files_creator.py
@@ -140,9 +140,68 @@ def test_clean_library_spectra(tmp_path, path_to_general_test_files):
                                             base_file_name,
                                             ion_mode="positive")
     test_create_files.clean_peaks_and_normalise_intensities_spectra()
+    cleaned_spectra = test_create_files.list_of_spectra
+    # Check if the spectra are still correct, output is not checked
+    assert len(cleaned_spectra) == 2, "two spectra were expected after cleaning"
+    assert isinstance(cleaned_spectra[0], Spectrum) and isinstance(cleaned_spectra[1], Spectrum), "Expected a list with two spectrum objects"
+
+
+def test_clean_up_smiles_inchi_and_inchikeys(tmp_path, path_to_general_test_files):
+    base_file_name = os.path.join(tmp_path, '100_test_spectra')
+
+    spectrum1 = Spectrum(
+        mz=np.array([808.27356, 872.289917, 890.246277, 891.272888, 894.326416, 904.195679,
+                     905.224548, 908.183472, 922.178101, 923.155762], dtype="float"),
+        intensities=np.array([0.11106008, 0.12347332, 0.16352988, 0.17101522, 0.17312992, 0.19262333, 0.21442898,
+                              0.42173288, 0.51071955, 1.], dtype="float"),
+        metadata={'pepmass': (907.0, None), 'spectrumid': 'CCMSLIB00000001760', 'precursor_mz': 907.0,
+                  'smiles': 'CCCC', 'ionmode': "positive"})
+    spectrum2 = Spectrum(
+        mz=np.array([538.003174, 539.217773], dtype="float"),
+        intensities=np.array([0.28046377, 0.28900242], dtype="float"),
+        metadata={'pepmass': (928.0, None), 'spectrumid': 'CCMSLIB00000001761', 'precursor_mz': 342.30,
+                  'compound_name': 'sucrose', "ionmode": "positive"})
+    library_spectra = [spectrum1, spectrum2]
+    test_create_files = LibraryFilesCreator(library_spectra,
+                                            base_file_name,
+                                            ion_mode="positive")
     test_create_files.clean_up_smiles_inchi_and_inchikeys(True)
+    cleaned_spectra = test_create_files.list_of_spectra
+    # Check if the spectra are still correct, output is not checked
+    assert len(cleaned_spectra) == 2, "two spectra were expected after cleaning"
+    for i, spectrum in enumerate(cleaned_spectra):
+        assert isinstance(spectrum, Spectrum), "Expected a list with spectra objects"
+        assert spectrum.peaks == library_spectra[i].peaks, 'Expected that the peaks are not altered'
+
+    assert cleaned_spectra[0].get("smiles") == "CCCC"
+    assert cleaned_spectra[0].get("inchikey") == "IJDNQMDRQITEOD-UHFFFAOYSA-N"
+    assert cleaned_spectra[0].get("inchi") == "InChI=1S/C4H10/c1-3-4-2/h3-4H2,1-2H3"
+
+    assert cleaned_spectra[1].get("smiles") == "C([C@@H]1[C@H]([C@@H]([C@H]([C@H](O1)O[C@]2([C@H]([C@@H]([C@H](O2)CO)O)O)CO)O)O)O)O"
+    assert cleaned_spectra[1].get("inchikey") == "CZMRCDWAGMRECN-UGDNZRGBSA-N"
+    assert cleaned_spectra[1].get("inchi") == '"InChI=1S/C12H22O11/c13-1-4-6(16)8(18)9(19)11(21-4)23-12(3-15)10(20)7(17)5(2-14)22-12/h4-11,13-20H,1-3H2/t4-,5-,6-,7-,8+,9-,10+,11-,12+/m1/s1"'
+
+
+def test_remove_not_fully_annotated_spectra(tmp_path, path_to_general_test_files):
+    base_file_name = os.path.join(tmp_path, '100_test_spectra')
+
+    spectrum1 = Spectrum(
+        mz=np.array([808.27356, 872.289917, 890.246277, 891.272888, 894.326416, 904.195679,
+                     905.224548, 908.183472, 922.178101, 923.155762], dtype="float"),
+        intensities=np.array([0.11106008, 0.12347332, 0.16352988, 0.17101522, 0.17312992, 0.19262333, 0.21442898,
+                              0.42173288, 0.51071955, 1.], dtype="float"),
+        metadata={'pepmass': (907.0, None), 'spectrumid': 'CCMSLIB00000001760', 'precursor_mz': 907.0,
+                  'smiles': 'CCCC', "inchikey": "AAAAAAAAAAAAAAAA", "inchi": "this is a test inci", 'ionmode': "positive", "charge": 1})
+    spectrum2 = Spectrum(
+        mz=np.array([538.003174, 539.217773], dtype="float"),
+        intensities=np.array([0.28046377, 0.28900242], dtype="float"),
+        metadata={'pepmass': (928.0, None), 'spectrumid': 'CCMSLIB00000001761', 'precursor_mz': 342.30,
+                  'compound_name': 'sucrose', "ionmode": "positive"})
+    library_spectra = [spectrum1, spectrum2]
+    test_create_files = LibraryFilesCreator(library_spectra,
+                                            base_file_name,
+                                            ion_mode="positive")
     test_create_files.remove_not_fully_annotated_spectra()
-    filtered_spectra = test_create_files.list_of_spectra
-    print(filtered_spectra[0].metadata)
-    print(filtered_spectra[1].metadata)
-    assert False
+    results = test_create_files.list_of_spectra
+    assert len(results) == 1, "Expected that 1 spectrum was removed"
+    assert spectrum1.__eq__(results[0]), "Expected an unaltered spectra"

--- a/tests/test_library_files_creator.py
+++ b/tests/test_library_files_creator.py
@@ -55,51 +55,6 @@ def test_give_already_used_file_name(tmp_path):
                   pickled_spectra_file_name, base_file_name)
 
 
-def test_create_all_library_files(tmp_path, path_to_general_test_files):
-    """Tests create_all_library_files"""
-    base_file_name = os.path.join(tmp_path, '100_test_spectra')
-    test_create_files = LibraryFilesCreator(os.path.join(
-        path_to_general_test_files, '100_test_spectra.pickle'), base_file_name,
-        ion_mode="positive",
-        tanimoto_scores_file_name=os.path.join(path_to_general_test_files, '100_test_spectra_tanimoto_scores.pickle', ),
-        s2v_model_file_name=os.path.join(path_to_general_test_files, '100_test_spectra_s2v_model.model'),
-        ms2ds_model_file_name=os.path.join(path_to_general_test_files, 'ms2ds_siamese_210301_5000_500_400.hdf5'))
-    test_create_files.clean_spectra(False)
-    test_create_files.create_all_library_files()
-
-    expected_ms2ds_emb_file_name = base_file_name + "_ms2ds_embeddings.pickle"
-    expected_s2v_emb_file_name = base_file_name + "_s2v_embeddings.pickle"
-    expected_sqlite_file_name = base_file_name + ".sqlite"
-    assert os.path.isfile(expected_ms2ds_emb_file_name), \
-        "Expected ms2ds embeddings file to be created"
-    assert os.path.isfile(expected_s2v_emb_file_name), \
-        "Expected s2v file to be created"
-    assert os.path.isfile(expected_sqlite_file_name), \
-        "Expected sqlite file to be created"
-    # Test if correct embeddings are stored
-    ms2ds_embeddings = load_pickled_file(expected_ms2ds_emb_file_name)
-    s2v_embeddings = load_pickled_file(expected_s2v_emb_file_name)
-    expected_s2v_embeddings = load_pickled_file(os.path.join(
-        path_to_general_test_files,
-        "test_files_without_spectrum_id",
-        "100_test_spectra_s2v_embeddings.pickle"))
-    expected_ms2ds_embeddings = load_pickled_file(os.path.join(
-        path_to_general_test_files,
-        "test_files_without_spectrum_id",
-        "100_test_spectra_ms2ds_embeddings.pickle"))
-    pd.testing.assert_frame_equal(ms2ds_embeddings,
-                                  expected_ms2ds_embeddings,
-                                  check_exact=False,
-                                  atol=1e-5)
-    pd.testing.assert_frame_equal(s2v_embeddings,
-                                  expected_s2v_embeddings,
-                                  check_exact=False,
-                                  atol=1e-5)
-    # Check if sqlite file is stored correctly, is disabled since metadata is changed by filtering
-    # check_sqlite_files_are_equal(expected_sqlite_file_name, os.path.join(
-    #     path_to_general_test_files, "test_files_without_spectrum_id", "100_test_spectra.sqlite"))
-
-
 def test_store_ms2ds_embeddings(tmp_path, path_to_general_test_files):
     """Tests store_ms2ds_embeddings"""
     base_file_name = os.path.join(tmp_path, '100_test_spectra')

--- a/tests/test_library_files_creator.py
+++ b/tests/test_library_files_creator.py
@@ -9,9 +9,8 @@ from .test_sqlite import check_sqlite_files_are_equal
 @pytest.fixture
 def path_to_general_test_files() -> str:
     return os.path.join(
-        os.path.split(os.path.dirname(__file__))[0],
+        os.getcwd(),
         'tests/test_files/general_test_files')
-
 
 def test_set_settings_correct(path_to_general_test_files):
     """Tests if settings are set correctly"""
@@ -61,10 +60,11 @@ def test_create_all_library_files(tmp_path, path_to_general_test_files):
     base_file_name = os.path.join(tmp_path, '100_test_spectra')
     test_create_files = LibraryFilesCreator(os.path.join(
         path_to_general_test_files, '100_test_spectra.pickle'), base_file_name,
+        ion_mode="positive",
         tanimoto_scores_file_name=os.path.join(path_to_general_test_files, '100_test_spectra_tanimoto_scores.pickle', ),
         s2v_model_file_name=os.path.join(path_to_general_test_files, '100_test_spectra_s2v_model.model'),
         ms2ds_model_file_name=os.path.join(path_to_general_test_files, 'ms2ds_siamese_210301_5000_500_400.hdf5'))
-
+    test_create_files.clean_spectra(False)
     test_create_files.create_all_library_files()
 
     expected_ms2ds_emb_file_name = base_file_name + "_ms2ds_embeddings.pickle"
@@ -95,9 +95,9 @@ def test_create_all_library_files(tmp_path, path_to_general_test_files):
                                   expected_s2v_embeddings,
                                   check_exact=False,
                                   atol=1e-5)
-    # Check if sqlite file is stored correctly
-    check_sqlite_files_are_equal(expected_sqlite_file_name, os.path.join(
-        path_to_general_test_files, "test_files_without_spectrum_id", "100_test_spectra.sqlite"))
+    # Check if sqlite file is stored correctly, is disabled since metadata is changed by filtering
+    # check_sqlite_files_are_equal(expected_sqlite_file_name, os.path.join(
+    #     path_to_general_test_files, "test_files_without_spectrum_id", "100_test_spectra.sqlite"))
 
 
 def test_store_ms2ds_embeddings(tmp_path, path_to_general_test_files):
@@ -106,6 +106,7 @@ def test_store_ms2ds_embeddings(tmp_path, path_to_general_test_files):
     test_create_files = LibraryFilesCreator(os.path.join(
         path_to_general_test_files, '100_test_spectra.pickle'), base_file_name,
         ms2ds_model_file_name=os.path.join(path_to_general_test_files, 'ms2ds_siamese_210301_5000_500_400.hdf5'))
+    test_create_files.clean_spectra()
     test_create_files.store_ms2ds_embeddings()
 
     new_embeddings_file_name = base_file_name + "_ms2ds_embeddings.pickle"
@@ -128,6 +129,7 @@ def test_store_s2v_embeddings(tmp_path, path_to_general_test_files):
     test_create_files = LibraryFilesCreator(os.path.join(
         path_to_general_test_files, '100_test_spectra.pickle'), base_file_name,
         s2v_model_file_name=os.path.join(path_to_general_test_files, "100_test_spectra_s2v_model.model"))
+    test_create_files.clean_spectra()
     test_create_files.store_s2v_embeddings()
 
     new_embeddings_file_name = base_file_name + "_s2v_embeddings.pickle"

--- a/tests/test_library_files_creator.py
+++ b/tests/test_library_files_creator.py
@@ -63,14 +63,12 @@ def test_create_all_library_files(tmp_path, path_to_general_test_files):
     test_create_files = LibraryFilesCreator(os.path.join(
         path_to_general_test_files, '100_test_spectra.pickle'),
         base_file_name,
-        tanimoto_scores_file_name=os.path.join(path_to_general_test_files, '100_test_spectra_tanimoto_scores.pickle')
+        tanimoto_scores_file_name=os.path.join(path_to_general_test_files, '100_test_spectra_tanimoto_scores.pickle',),
+        s2v_model_file_name=os.path.join(path_to_general_test_files, '100_test_spectra_s2v_model.model'),
+        ms2ds_model_file_name=os.path.join(path_to_general_test_files, 'ms2ds_siamese_210301_5000_500_400.hdf5')
     )
 
-    test_create_files.create_all_library_files(
-        os.path.join(path_to_general_test_files,
-                     'ms2ds_siamese_210301_5000_500_400.hdf5'),
-        os.path.join(path_to_general_test_files,
-                     '100_test_spectra_s2v_model.model'))
+    test_create_files.create_all_library_files()
 
     expected_ms2ds_emb_file_name = base_file_name + "_ms2ds_embeddings.pickle"
     expected_s2v_emb_file_name = base_file_name + "_s2v_embeddings.pickle"
@@ -110,10 +108,9 @@ def test_store_ms2ds_embeddings(tmp_path, path_to_general_test_files):
     base_file_name = os.path.join(tmp_path, '100_test_spectra')
     test_create_files = LibraryFilesCreator(os.path.join(
         path_to_general_test_files, '100_test_spectra.pickle'),
-        base_file_name)
-    test_create_files.store_ms2ds_embeddings(os.path.join(
-        path_to_general_test_files,
-        'ms2ds_siamese_210301_5000_500_400.hdf5'))
+        base_file_name,
+        ms2ds_model_file_name=os.path.join(path_to_general_test_files, 'ms2ds_siamese_210301_5000_500_400.hdf5'))
+    test_create_files.store_ms2ds_embeddings()
 
     new_embeddings_file_name = base_file_name + "_ms2ds_embeddings.pickle"
     assert os.path.isfile(new_embeddings_file_name), \
@@ -134,10 +131,9 @@ def test_store_s2v_embeddings(tmp_path, path_to_general_test_files):
     base_file_name = os.path.join(tmp_path, '100_test_spectra')
     test_create_files = LibraryFilesCreator(os.path.join(
         path_to_general_test_files, '100_test_spectra.pickle'),
-        base_file_name)
-    test_create_files.store_s2v_embeddings(os.path.join(
-        path_to_general_test_files,
-        "100_test_spectra_s2v_model.model"))
+        base_file_name,
+        s2v_model_file_name=os.path.join(path_to_general_test_files, "100_test_spectra_s2v_model.model"))
+    test_create_files.store_s2v_embeddings()
 
     new_embeddings_file_name = base_file_name + "_s2v_embeddings.pickle"
     assert os.path.isfile(new_embeddings_file_name), \

--- a/tests/test_library_files_creator.py
+++ b/tests/test_library_files_creator.py
@@ -1,10 +1,11 @@
 import os
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pytest
 from matchms import Spectrum
 from ms2query.library_files_creator import LibraryFilesCreator
-from ms2query.utils import load_pickled_file, convert_files_to_matchms_spectrum_objects
+from ms2query.utils import (convert_files_to_matchms_spectrum_objects,
+                            load_pickled_file)
 
 
 @pytest.fixture

--- a/tests/test_sqlite.py
+++ b/tests/test_sqlite.py
@@ -83,12 +83,12 @@ def test_making_sqlite_file(tmp_path):
         path_to_general_test_files, "100_test_spectra.pickle"))
     list_of_spectra = minimal_processing_multiple_spectra(list_of_spectra)
 
-    tanimoto_scores_file_name = os.path.join(
-        path_to_general_test_files, "100_test_spectra_tanimoto_scores.pickle")
+    tanimoto_scores = load_pickled_file(os.path.join(
+        path_to_general_test_files, "100_test_spectra_tanimoto_scores.pickle"))
 
     # Create sqlite file, with 3 tables
     make_sqlfile_wrapper(new_sqlite_file_name,
-                         tanimoto_scores_file_name,
+                         tanimoto_scores,
                          list_of_spectra,
                          columns_dict={"precursor_mz": "REAL"})
     check_sqlite_files_are_equal(new_sqlite_file_name, reference_sqlite_file)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,14 +8,6 @@ from ms2query.utils import (add_unknown_charges_to_spectra,
                             get_classifier_from_csv_file, load_pickled_file)
 
 
-def test_convert_files_to_matchms_spectrum_objects_unknown_file_extension(tmp_path):
-    """Test if None is returned when the file extension is not known"""
-    test_text_file_name = os.path.join(tmp_path, "test_txt_file.txt")
-    with open(test_text_file_name, "w") as test_txt_file:
-        test_txt_file.write("test")
-    assert convert_files_to_matchms_spectrum_objects(test_text_file_name) is None, "expected None for .txt extension"
-
-
 def test_convert_files_to_matchms_spectrum_objects_unknown_file(tmp_path):
     """Tests if unknown file raises an Assertion error"""
     with pytest.raises(AssertionError):


### PR DESCRIPTION
The structure of the LibraryFilesCreator class was not very intuitive. This pull request solves that

Changes:
Define all parameters in init, instead of in functions.
Use loaded Tanimoto scores as input for create_sqlite_file, instead of giving the pickled file name. 
Added calculate Tanimoto scores

To do:
Add explanation to readme. 
Add filtering of metadata + ion mode to LibraryFilesCreator (currently still in notebooks)