### PR TITLE
Return dataframe instead of results table

### DIFF
--- a/ms2query/create_new_library/train_ms2query_model.py
+++ b/ms2query/create_new_library/train_ms2query_model.py
@@ -53,8 +53,7 @@ class DataCollectorForTraining():
         all_tanimoto_scores = pd.DataFrame()
         info_of_matches_with_tanimoto = pd.DataFrame()
         for query_spectrum in tqdm(query_spectra,
-                                   desc="Get scores and tanimoto scores",
-                                   disable=not self.ms2library.settings["progress_bars"]):
+                                   desc="Get scores and tanimoto scores"):
             results_table = self.ms2library.calculate_features_single_spectrum(query_spectrum,
                                                                                self.preselection_cut_off)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,12 +45,10 @@ def ms2library() -> MS2Library:
     ms2ds_embeddings_file_name = os.path.join(
         path_to_tests_dir,
         "general_test_files/100_test_spectra_ms2ds_embeddings.pickle")
-    spectrum_id_column_name = "spectrumid"
     ms2q_model_file_name = os.path.join(path_to_tests_dir,
         "general_test_files", "test_ms2q_rf_model.onnx")
     ms2library = MS2Library(sqlite_file_loc, spec2vec_model_file_loc, ms2ds_model_file_name,
-                            s2v_pickled_embeddings_file, ms2ds_embeddings_file_name, ms2q_model_file_name,
-                            spectrum_id_column_name=spectrum_id_column_name)
+                            s2v_pickled_embeddings_file, ms2ds_embeddings_file_name, ms2q_model_file_name)
     return ms2library
 
 

--- a/tests/test_ms2library.py
+++ b/tests/test_ms2library.py
@@ -18,15 +18,6 @@ def expected_ms2deespcore_scores():
     return ms2dscores
 
 
-def test_ms2library_set_settings(ms2library):
-    """Tests creating a ms2library object"""
-
-    assert ms2library.settings["spectrum_id_column_name"] == "spectrumid", \
-        "Different value for attribute was expected"
-    assert ms2library.settings["progress_bars"] == True, \
-        "Different value for attribute was expected"
-
-
 def test_get_all_ms2ds_scores(ms2library, test_spectra, expected_ms2deespcore_scores):
     """Test get_all_ms2ds_scores method of ms2library"""
     result = ms2library._get_all_ms2ds_scores(test_spectra[0])

--- a/tests/test_ms2library.py
+++ b/tests/test_ms2library.py
@@ -110,5 +110,10 @@ def test_create_library_object_from_one_dir():
     assert isinstance(library, MS2Library)
 
 
-if __name__ == "__main__":
-    pass
+def test_analog_yield_df(ms2library, test_spectra, tmp_path):
+    settings = SettingsRunMS2Query(additional_metadata_columns=("spectrumid", ),)
+    result = ms2library.analog_search_yield_df(test_spectra, settings)
+    expected_headers = \
+        ['query_spectrum_nr', "ms2query_model_prediction", "precursor_mz_difference", "precursor_mz_query_spectrum",
+         "precursor_mz_analog", "inchikey", "analog_compound_name", "smiles", "spectrumid"]
+    check_correct_results_csv_file(list(result)[0], expected_headers, nr_of_rows_to_check=1)

--- a/tests/test_results_table.py
+++ b/tests/test_results_table.py
@@ -3,8 +3,6 @@ import pandas as pd
 import pytest
 from matchms import Spectrum
 from ms2query import ResultsTable
-from ms2query.utils import column_names_for_output
-from tests.test_utils import check_correct_results_csv_file
 
 
 @pytest.fixture


### PR DESCRIPTION
@florian-huber I never worked with generator/yield before, so could you check that this architecture makes sense? 

The command line version of MS2Query creates a csv file, but in addition there is the option to return the results table objects. 
The rational was that other tools can use this to retrieve anything they want from the results table e.g. the ms2deepscore scores.

This gave a few issues:
- Mainting tests for this kind of functions is very difficult, since it stores an object, whenever the architecture of the results table changes the expected object has to be changed. 
- For other tools working with the results table object is very confusing and also a large risk of backwards compatiility issues. 
- We had two functions: one to create the csv and one for returning results tables. Having two points with almost the same code. When updating something this means updating the code twice, which is more time consuming and has more risks for introducing errors. 

Solution: 
- Return df instead of results table object, solves #185 
- Yield the df instead of return to make it possible to, solves #155

Note: Merging into classes in sqlite to have a clear overview of what is new in this PR, since classes in sqlite will soon be merged into main. 