### PR TITLE
Change zenodo identifier to specific version

### DIFF
--- a/ms2query/run_ms2query.py
+++ b/ms2query/run_ms2query.py
@@ -8,8 +8,8 @@ from ms2query.utils import load_matchms_spectrum_objects_from_file, SettingsRunM
 
 def zenodo_dois(ionisation_mode):
     "Returns the most up to date url for Zenodo"
-    zenodo_DOIs = {"positive": 6124552,
-                   "negative": 7104184}
+    zenodo_DOIs = {"positive": 7947603,
+                   "negative": 7944658}
     assert ionisation_mode in zenodo_DOIs, "Expected 'positive' or 'negative' as input"
     zenodo_doi = zenodo_DOIs[ionisation_mode]
     zenodo_metadata_url = "https://zenodo.org/api/records/" + str(zenodo_doi)


### PR DESCRIPTION
The zenodo identifiers were set to the newest version. This makes updating easier, however, if it breaks backwards compatibility at some point this won't work anymore. And it will be impossible to change the specific version of the library for older versions. Therefore we will go back to specific versions to make sure the right models are still downloaded in old versions. 