### PR TITLE
Add embeddings to sqlite

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ library_creator = LibraryFilesCreator(cleaned_library_spectra,
                                       output_directory=directory_for_library_and_models,
                                       ms2ds_model_file_name=ms2ds_model_file_name,
                                       s2v_model_file_name=s2v_model_file_name, )
-library_creator.create_all_library_files()
+library_creator.create_sqlite_file()
 ```
 
 To run MS2Query on your own created library. Check out the instructions under Run MS2Query. Both command line and the code version should work.

--- a/ms2query/create_new_library/create_sqlite_database.py
+++ b/ms2query/create_new_library/create_sqlite_database.py
@@ -15,9 +15,12 @@ from ms2query.utils import return_non_existing_file_name
 
 def make_sqlfile_wrapper(sqlite_file_name: str,
                          list_of_spectra: List[Spectrum],
+                         ms2ds_embeddings: pd.DataFrame,
+                         s2v_embeddings: pd.DataFrame,
                          columns_dict: Dict[str, str] = None,
                          compound_classes: pd.DataFrame = None,
-                         progress_bars: bool = True):
+                         progress_bars: bool = True,
+                         ):
     """Wrapper to create sqlite file containing spectrum information needed for MS2Query
 
     Args:
@@ -53,6 +56,18 @@ def make_sqlfile_wrapper(sqlite_file_name: str,
     fill_inchikeys_table(sqlite_file_name, list_of_spectra,
                          compound_classes=compound_classes,
                          progress_bars=progress_bars)
+
+    add_dataframe_to_sqlite(sqlite_file_name, 'MS2Deepscore_embeddings', ms2ds_embeddings)
+    add_dataframe_to_sqlite(sqlite_file_name, 'Spec2Vec_embeddings', s2v_embeddings)
+
+
+def add_dataframe_to_sqlite(sqlite_file_name,
+                            table_name,
+                            dataframe: pd.DataFrame):
+    conn = sqlite3.connect(sqlite_file_name)
+    dataframe.to_sql(table_name, conn, if_exists='fail', index=True, index_label="spectrumid")
+    conn.commit()
+    conn.close()
 
 
 def initialize_tables(sqlite_file_name: str,

--- a/ms2query/create_new_library/train_models.py
+++ b/ms2query/create_new_library/train_models.py
@@ -79,7 +79,7 @@ def train_all_models(annotated_training_spectra,
                                                 spec2vec_model_file_name,
                                                 ms2deepscore_model_file_name,
                                                 add_compound_classes=settings.add_compound_classes)
-    library_files_creator.create_all_library_files()
+    library_files_creator.create_sqlite_file()
 
 
 def clean_and_train_models(spectrum_file: str,

--- a/ms2query/create_new_library/train_ms2query_model.py
+++ b/ms2query/create_new_library/train_ms2query_model.py
@@ -129,7 +129,7 @@ def train_ms2query_model(training_spectra,
                                                        s2v_model_file_name=s2v_model_file_name,
                                                        ms2ds_model_file_name=ms2ds_model_file_name,
                                                        add_compound_classes=False)
-    library_creator_for_training.create_all_library_files()
+    library_creator_for_training.create_sqlite_file()
 
     ms2library_for_training = MS2Library(sqlite_file_name=library_creator_for_training.sqlite_file_name,
                                          s2v_model_file_name=s2v_model_file_name,

--- a/tests/test_library_files_creator.py
+++ b/tests/test_library_files_creator.py
@@ -4,8 +4,6 @@ import pytest
 from ms2query.clean_and_filter_spectra import normalize_and_filter_peaks
 from ms2query.create_new_library.library_files_creator import \
     LibraryFilesCreator
-from ms2query.utils import (load_matchms_spectrum_objects_from_file,
-                            load_pickled_file)
 
 
 def test_give_already_used_file_name(tmp_path, path_to_general_test_files, hundred_test_spectra):
@@ -17,28 +15,22 @@ def test_give_already_used_file_name(tmp_path, path_to_general_test_files, hundr
         LibraryFilesCreator(hundred_test_spectra, tmp_path)
 
 
-def test_store_ms2ds_embeddings(tmp_path, path_to_general_test_files,
-                                hundred_test_spectra,
-                                expected_ms2ds_embeddings):
+def test_create_ms2ds_embeddings(tmp_path, path_to_general_test_files,
+                                 hundred_test_spectra,
+                                 expected_ms2ds_embeddings):
     """Tests store_ms2ds_embeddings"""
     base_file_name = os.path.join(tmp_path, '100_test_spectra')
     library_spectra = [normalize_and_filter_peaks(s) for s in hundred_test_spectra if s is not None]
     test_create_files = LibraryFilesCreator(library_spectra, base_file_name,
                                             ms2ds_model_file_name=os.path.join(path_to_general_test_files,
                                                                                'ms2ds_siamese_210301_5000_500_400.hdf5'))
-    test_create_files.store_ms2ds_embeddings()
-
-    new_embeddings_file_name = os.path.join(base_file_name, "ms2ds_embeddings.pickle")
-    assert os.path.isfile(new_embeddings_file_name), \
-        "Expected file to be created"
-    # Test if correct embeddings are stored
-    embeddings = load_pickled_file(new_embeddings_file_name)
+    embeddings = test_create_files.create_ms2ds_embeddings()
     pd.testing.assert_frame_equal(embeddings, expected_ms2ds_embeddings,
                                   check_exact=False,
                                   atol=1e-5)
 
 
-def test_store_s2v_embeddings(tmp_path, path_to_general_test_files, hundred_test_spectra,
+def test_create_s2v_embeddings(tmp_path, path_to_general_test_files, hundred_test_spectra,
                               expected_s2v_embeddings):
     """Tests store_ms2ds_embeddings"""
     base_file_name = os.path.join(tmp_path, '100_test_spectra')
@@ -46,20 +38,20 @@ def test_store_s2v_embeddings(tmp_path, path_to_general_test_files, hundred_test
     test_create_files = LibraryFilesCreator(library_spectra, base_file_name,
                                             s2v_model_file_name=os.path.join(path_to_general_test_files,
                                                                              "100_test_spectra_s2v_model.model"))
-    test_create_files.store_s2v_embeddings()
-
-    new_embeddings_file_name = os.path.join(base_file_name, "s2v_embeddings.pickle")
-    assert os.path.isfile(new_embeddings_file_name), \
-        "Expected file to be created"
-    embeddings = load_pickled_file(new_embeddings_file_name)
+    embeddings = test_create_files.create_s2v_embeddings()
     pd.testing.assert_frame_equal(embeddings, expected_s2v_embeddings,
                                   check_exact=False,
                                   atol=1e-5)
 
 
-def test_create_sqlite_file(tmp_path, path_to_general_test_files, hundred_test_spectra):
+def test_create_sqlite_file_with_embeddings(hundred_test_spectra, path_to_general_test_files):
     test_create_files = LibraryFilesCreator(
-        hundred_test_spectra[:20], output_directory=os.path.join(tmp_path, '100_test_spectra'),
-        add_compound_classes=False)
+        hundred_test_spectra[:20],
+        output_directory=os.path.join(path_to_general_test_files),
+        add_compound_classes=False,
+        ms2ds_model_file_name=os.path.join(path_to_general_test_files,
+                                           'ms2ds_siamese_210301_5000_500_400.hdf5'),
+        s2v_model_file_name=os.path.join(path_to_general_test_files,
+                                         "100_test_spectra_s2v_model.model")
+    )
     test_create_files.create_sqlite_file()
-


### PR DESCRIPTION
Quick attempt to incorporate embeddings into the sqlite file. Just realized that it would probably be pretty straightforward and it seems to be the case indeed. 
This will resolve our dependency on pandas important for solving #199 and #191.

- [ ] Store embeddings in sqlite
- [ ] Read ms2ds embeddings from sqlite
- [ ] Read s2v embeddings (optional, search for the 2000 ids each time) 
- [ ] Add test for s2v embeddings reading
- [ ] Make ms2library use new sqlite file
- [ ] Update all tests
- [ ] Update files on zenodo accordingly
