### PR TITLE
Set matchms version to max 0.26.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     test_suite="tests",
     python_requires='>=3.9',
     install_requires=[
-        "matchms>=0.24.0",
+        "matchms>=0.24.0,<=0.26.4",
         "numpy",
         "spec2vec>=0.6.0",
         "h5py",


### PR DESCRIPTION
In matchms 0.27 add_losses is removed, which leads to breaking changes in ms2query. Fixing is not trivial, since it requires updating spec2vec, since otherwise no loss_mz_from and loss_mz_to can be set. A start with making spec2vec matchms-0.27.0 compatible was made in https://github.com/iomega/spec2vec/pull/93 