### PR TITLE
Fix torch issue

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - h5py=3.11.0
   - pyarrow=16.1.0
   - scikit-learn=1.5.0
+  - torch=2.5.0
   - ms2deepscore=2.0.0
   - pandas=2.2.2
   - matplotlib=3.7.2

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - h5py=3.11.0
   - pyarrow=16.1.0
   - scikit-learn=1.5.0
-  - torch=2.5.0
+  - torch<2.6.0
   - ms2deepscore=2.0.0
   - pandas=2.2.2
   - matplotlib=3.7.2

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,6 @@ dependencies:
   - h5py=3.11.0
   - pyarrow=16.1.0
   - scikit-learn=1.5.0
-  - torch<2.6.0
   - ms2deepscore=2.0.0
   - pandas=2.2.2
   - matplotlib=3.7.2
@@ -20,3 +19,6 @@ dependencies:
   - pytest=8.2.2
   - pytest-cov=5.0.0
   - zip
+  - pip
+  - pip:
+      - torch<2.6

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     install_requires=[
         "matchms>=0.24.0,<=0.26.4",
         "numpy",
+        "torch<2.6",
         "spec2vec>=0.6.0",
         "h5py",
         "pyarrow",


### PR DESCRIPTION
Since pytorch 2.6 the model loading for ms2deepscore does not work anymore. 