### PR TITLE
Restrict Python version and update numpy requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,10 @@ setup(
     license="Apache Software License 2.0",
     zip_safe=False,
     test_suite="tests",
-    python_requires='>=3.9',
+    python_requires='>=3.9, <3.13',
     install_requires=[
         "matchms>=0.24.0,<=0.26.4",
-        "numpy",
+        "numpy<2.0", # Once fixed the python requied <3.13 can probably also be removed.
         "torch<2.6",
         "spec2vec>=0.6.0",
         "h5py",


### PR DESCRIPTION
Currently installing ms2query in python=3.13 results in a confusing error due to incompatibility with numpy 2.0 (No module found called numpy.distutils when installing a package). This change should give a clearer error, that an older python version should be used.